### PR TITLE
622 corrupted zim leads to crash

### DIFF
--- a/SwiftUI/Model/SearchOperation/SearchOperation.mm
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.mm
@@ -52,7 +52,7 @@
     // get a list of archives that are included in search
     typedef std::unordered_map<std::string, zim::Archive> archives_map;
     auto *allArchives = static_cast<archives_map *>([[ZimFileService sharedInstance] getArchives]);
-    
+
     std::vector<zim::Archive> indexSearchArchives = std::vector<zim::Archive>();
     std::vector<zim::Archive> titleSearchArchives = std::vector<zim::Archive>();
     for (NSUUID *zimFileID in self.zimFileIDs) {
@@ -63,9 +63,9 @@
                 indexSearchArchives.push_back(archive);
             }
             titleSearchArchives.push_back(archive);
-        } catch (std::out_of_range) { }
+        } catch (std::exception) { }
     }
-    
+
     // perform index and title search
     [self addIndexSearchResults:indexSearchArchives];
     if (titleSearchArchives.size() > 0) {

--- a/SwiftUI/Model/SearchOperation/SearchOperation.mm
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.mm
@@ -67,7 +67,9 @@
     }
 
     // perform index and title search
-    [self addIndexSearchResults:indexSearchArchives];
+    try {
+        [self addIndexSearchResults:indexSearchArchives];
+    } catch (std::exception) { }
     if (titleSearchArchives.size() > 0) {
         int count = std::max((35 - (int)[self.results count]) / (int)titleSearchArchives.size(), 5);
         [self addTitleSearchResults:titleSearchArchives count:(int)count];


### PR DESCRIPTION
Preparing for handling standard exception raised as part of #622 .

Fixes #622 