### PR TITLE
Seek videos

### DIFF
--- a/Support/Info.plist
+++ b/Support/Info.plist
@@ -36,7 +36,9 @@
 	<false/>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>audio</string>
 		<string>fetch</string>
+		<string>processing</string>
 	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>


### PR DESCRIPTION
Relates to: #215 
This PR is a summary of my findings so far, and a minor fix for iOS, by adding the background processing and audio capabilities to the apps.


So far by using the test TED ZIM file for videos, I have found the following:

**iOS:** 
There are only small issues really: 
- when you first load a page with the video, it will start the audio but the screen will be black. If you close the video (fullscreen) and re-open the same video, everything is fine. Also if you toggle to Picture in Picture that fixes it as well.
- I couldn't make it stream to Apple TV via Airplay for some reason
Other than these 2 issues, it works perfectly, you can scrub, mute, change subtitles, use picture and picture, which properly closes if you leave the page, and even resumes when you go back. The playback (audio) can be continued even on the Lock Screen, which is nice. 
Note: strangely, if I opened the link on my phone and started the video in Safari (outside of the Kiwix app), it starts OK without the black screen (sometimes with some initial buffering hick-ups). 
Note: it doesn't work properly on the Simulator (well most audio / video usually less than perfect on simulators anyway), but works great on the device.

See a short demo:
https://github.com/kiwix/kiwix-apple/assets/6784320/089efac7-8881-4955-8a33-9d2b5734947c


**macOS:**
It is somewhat a different story here:
- It starts the video great, there's no black screen, you can scrub, mute, and even control it from the system top tab-bar.
- The problem is: I could not enter full screen mode, no matter how hard I tried.
- It is possible to change subtitles, but the pop-over is really small and cluttered.
- If you right-click on the video, you can "enable" video controls, which will show a 2nd video control behind the current one, which is mostly un-clickable, but looks more like one provided by the system (more native).
- Also in the right click menu there's an option to enter full screen, but that's not working either.
See the screenshots:

<img width="851" alt="right_menu" src="https://github.com/kiwix/kiwix-apple/assets/6784320/e406ed0a-4877-4b59-ae58-5019bd74ebaa">
<img width="534" alt="double_controls" src="https://github.com/kiwix/kiwix-apple/assets/6784320/9390861f-2225-4869-9d97-1df454309879">

