### PR TITLE
Move video content loading off the main thread

### DIFF
--- a/Model/Utilities/WebKitHandler.swift
+++ b/Model/Utilities/WebKitHandler.swift
@@ -60,75 +60,90 @@ final class KiwixURLSchemeHandler: NSObject, WKURLSchemeHandler {
         let hash = urlSchemeTask.hash
         guard isStartedFor(hash) == false else { return }
         startFor(hash)
-
         queue.async { [weak self] in
-            let request = urlSchemeTask.request
-            guard let url = request.url, url.isKiwixURL else {
-                urlSchemeTask.didFailWithError(URLError(.unsupportedURL))
-                self?.stopFor(hash)
-                return
+            Task { [weak self] in
+                await self?.handle(task: urlSchemeTask)
             }
-            var start: UInt = 0
-            var end: UInt = 0
-            var isVideo = false
-            if let mimeType = ZimFileService.shared.getMimeType(url: url) {
-                isVideo = mimeType.contains("video")
-                if isVideo {
-                    if let range = request.allHTTPHeaderFields?["Range"] as? String {
-                        let parts = range.components(separatedBy: ["=", "-"])
-                        guard parts.count > 1, let rangeStart = UInt(parts[1]) else {
-                            self?.sendHTTP400Response(urlSchemeTask, url: url)
-                            return
-                        }
-                        let rangeEnd = parts.count == 3 ? UInt(parts[2]) ?? 0 : 0
-                        start = rangeStart
-                        end = rangeEnd
+        }
+    }
+
+    private func handle(task urlSchemeTask: WKURLSchemeTask) async {
+        let request = urlSchemeTask.request
+        let hash = urlSchemeTask.hash
+        guard let url = request.url, url.isKiwixURL else {
+            urlSchemeTask.didFailWithError(URLError(.unsupportedURL))
+            stopFor(hash)
+            return
+        }
+        var start: UInt = 0
+        var end: UInt = 0
+        var isVideo = false
+        if let mimeType = ZimFileService.shared.getMimeType(url: url) {
+            isVideo = mimeType.contains("video")
+            if isVideo {
+                if let range = request.allHTTPHeaderFields?["Range"] as? String {
+                    let parts = range.components(separatedBy: ["=", "-"])
+                    guard parts.count > 1, let rangeStart = UInt(parts[1]) else {
+                        sendHTTP400Response(urlSchemeTask, url: url)
+                        return
                     }
+                    let rangeEnd = parts.count == 3 ? UInt(parts[2]) ?? 0 : 0
+                    start = rangeStart
+                    end = rangeEnd
                 }
             }
-            guard let content = ZimFileService.shared.getURLContent(url: url, start: start, end: end) else {
-                self?.sendHTTP404Response(urlSchemeTask, url: url)
-                self?.stopFor(hash)
-                return
+        }
+        guard let content = await readContent(for: url, start: start, end: end) else {
+            sendHTTP404Response(urlSchemeTask, url: url)
+            stopFor(hash)
+            return
+        }
+        if isVideo {
+            sendHTTP206Response(urlSchemeTask, url: url, content: content, start: start, end: end)
+        } else {
+            sendHTTP200Response(urlSchemeTask, url: url, content: content)
+        }
+        stopFor(hash)
+    }
+
+    // MARK: Reading content
+
+    private func readContent(for url: URL, start: UInt = 0, end: UInt = 0) async -> URLContent? {
+        return await withCheckedContinuation { continuation in
+            Task.detached(priority: .utility) {
+                let content = ZimFileService.shared.getURLContent(url: url, start: start, end: end)
+                continuation.resume(returning: content)
             }
-            if isVideo {
-                self?.sendHTTP206Response(urlSchemeTask, url: url, content: content, start: start, end: end)
-            } else {
-                self?.sendHTTP200Response(urlSchemeTask, url: url, content: content)
-            }
-            self?.stopFor(hash)
         }
     }
 
     // MARK: Success responses
 
     private func sendHTTP200Response(_ urlSchemeTask: WKURLSchemeTask, url: URL, content: URLContent) {
+        guard isStartedFor(urlSchemeTask.hash) else { return }
         var headers = defaultResponseHeaders(for: content)
         headers["Content-Length"] = "\(content.size)"
 
         if let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: headers) {
-            guard isStartedFor(urlSchemeTask.hash) else { return }
             urlSchemeTask.didReceive(response)
             urlSchemeTask.didReceive(content.data)
             urlSchemeTask.didFinish()
         } else {
-            guard isStartedFor(urlSchemeTask.hash) else { return }
             urlSchemeTask.didFailWithError(URLError(.badServerResponse, userInfo: ["url": url]))
         }
     }
 
     private func sendHTTP206Response(_ urlSchemeTask: WKURLSchemeTask, url: URL, content: URLContent, start: UInt, end: UInt) {
+        guard isStartedFor(urlSchemeTask.hash) else { return }
         var headers = defaultResponseHeaders(for: content)
         headers["Content-Length"] = "\(content.rangeSize)"
         headers["Content-Range"] = content.contentRange(from: start, requestedEnd: end)
 
         if let response = HTTPURLResponse(url: url, statusCode: 206, httpVersion: "HTTP/1.1", headerFields: headers) {
-            guard isStartedFor(urlSchemeTask.hash) else { return }
             urlSchemeTask.didReceive(response)
             urlSchemeTask.didReceive(content.data)
             urlSchemeTask.didFinish()
         } else {
-            guard isStartedFor(urlSchemeTask.hash) else { return }
             urlSchemeTask.didFailWithError(URLError(.badServerResponse, userInfo: ["url": url]))
         }
     }
@@ -168,12 +183,11 @@ final class KiwixURLSchemeHandler: NSObject, WKURLSchemeHandler {
     }
 
     private func sendHTTP404Response(_ urlSchemeTask: WKURLSchemeTask, url: URL) {
+        guard isStartedFor(urlSchemeTask.hash) else { return }
         if let response = HTTPURLResponse(url: url, statusCode: 404, httpVersion: "HTTP/1.1", headerFields: nil) {
-            guard isStartedFor(urlSchemeTask.hash) else { return }
             urlSchemeTask.didReceive(response)
             urlSchemeTask.didFinish()
         } else {
-            guard isStartedFor(urlSchemeTask.hash) else { return }
             urlSchemeTask.didFailWithError(URLError(.badServerResponse, userInfo: ["url": url]))
         }
     }


### PR DESCRIPTION
On top of: #767
Related to: #744

Creating a more smooth UX, for loading html content, especially large item, such as videos.

The former solution was loading the content (including video content) on the main thread of the application, as part of a synchronised queue. In practice it meant, that the UI became unresponsive while the video was loading.

To solve this, we can read the content on a utility thread, and once completed there, we can send the results back to WebKit.

**Before**: it was possible to block the UI thread with larger videos (that were not pre-loaded yet), even the "rainbow spinning wheel" was visible on macOS.
**After**: the UI remains responsive (the user can eg. scroll in the meantime), no more system spinning wheel, instead the video loading animation is visible, which is a lot better.
