### PR TITLE
773 streaming uncompressed data

### DIFF
--- a/Model/Entities/Entities.swift
+++ b/Model/Entities/Entities.swift
@@ -30,6 +30,7 @@ class Bookmark: NSManagedObject, Identifiable {
     class func fetchRequest(
         predicate: NSPredicate? = nil, sortDescriptors: [NSSortDescriptor] = []
     ) -> NSFetchRequest<Bookmark> {
+        // swiftlint:disable:next force_cast
         let request = super.fetchRequest() as! NSFetchRequest<Bookmark>
         request.predicate = predicate
         request.sortDescriptors = sortDescriptors
@@ -50,12 +51,14 @@ class DownloadTask: NSManagedObject, Identifiable {
     @NSManaged var zimFile: ZimFile?
 
     class func fetchRequest(predicate: NSPredicate? = nil) -> NSFetchRequest<DownloadTask> {
+        // swiftlint:disable:next force_cast
         let request = super.fetchRequest() as! NSFetchRequest<DownloadTask>
         request.predicate = predicate
         return request
     }
 
     class func fetchRequest(fileID: UUID) -> NSFetchRequest<DownloadTask> {
+        // swiftlint:disable:next force_cast
         let request = super.fetchRequest() as! NSFetchRequest<DownloadTask>
         request.predicate = NSPredicate(format: "fileID == %@", fileID as CVarArg)
         return request
@@ -134,6 +137,7 @@ class Tab: NSManagedObject, Identifiable {
     class func fetchRequest(
         predicate: NSPredicate? = nil, sortDescriptors: [NSSortDescriptor] = []
     ) -> NSFetchRequest<Tab> {
+        // swiftlint:disable:next force_cast
         let request = super.fetchRequest() as! NSFetchRequest<Tab>
         request.predicate = predicate
         request.sortDescriptors = sortDescriptors
@@ -141,25 +145,50 @@ class Tab: NSManagedObject, Identifiable {
     }
 
     class func fetchRequest(id: UUID) -> NSFetchRequest<Tab> {
+        // swiftlint:disable:next force_cast
         let request = super.fetchRequest() as! NSFetchRequest<Tab>
         request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
         return request
     }
 }
 
-struct URLContent {
-    let data: Data
+struct URLContentMetaData {
     let mime: String
-    let start: UInt
-    let end: UInt
     let size: UInt
-
     var httpContentType: String {
         if mime == "text/plain" {
             return "text/plain;charset=UTf-8"
         } else {
             return mime
         }
+    }
+
+    var isMediaType: Bool {
+        mime.hasPrefix("video/") || mime.hasPrefix("audio/")
+    }
+}
+
+struct URLContent {
+    let data: Data
+    let start: UInt
+    let end: UInt
+}
+
+struct DirectAccessInfo {
+    let path: String
+    let offset: UInt
+
+    /// Optional init
+    /// @see: ``zim::Item.getDirectAccessInformation()``
+    /// - Parameters:
+    ///   - path: filename path - cannot be empty
+    ///   - offset: where the reading should start in the file
+    init?(path: String, offset: UInt) {
+        guard !path.isEmpty else {
+            return nil
+        }
+        self.path = path
+        self.offset = offset
     }
 }
 
@@ -214,6 +243,7 @@ final class ZimFile: NSManagedObject, Identifiable {
     class func fetchRequest(
         predicate: NSPredicate? = nil, sortDescriptors: [NSSortDescriptor] = []
     ) -> NSFetchRequest<ZimFile> {
+        // swiftlint:disable:next force_cast
         let request = super.fetchRequest() as! NSFetchRequest<ZimFile>
         request.predicate = predicate
         request.sortDescriptors = sortDescriptors
@@ -221,6 +251,7 @@ final class ZimFile: NSManagedObject, Identifiable {
     }
 
     class func fetchRequest(fileID: UUID) -> NSFetchRequest<ZimFile> {
+        // swiftlint:disable:next force_cast
         let request = super.fetchRequest() as! NSFetchRequest<ZimFile>
         request.predicate = NSPredicate(format: "fileID == %@", fileID as CVarArg)
         return request

--- a/Model/Utilities/ByteRanges.swift
+++ b/Model/Utilities/ByteRanges.swift
@@ -1,0 +1,29 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+
+enum ByteRanges {
+
+    static func rangesFor(contentLength: UInt, rangeSize size: UInt) -> [ClosedRange<UInt>] {
+        guard size > 0 else {
+            return []
+        }
+        return stride(from: 0, to: contentLength, by: UInt.Stride(size)).map { point in
+            let endOfRange = min(contentLength - 1, point + size - 1)
+            return point...endOfRange
+        }
+    }
+}

--- a/Model/Utilities/DataStream.swift
+++ b/Model/Utilities/DataStream.swift
@@ -1,0 +1,64 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+
+/// Returns an async sequence of data in chunks defined by range size
+struct DataStream<Element>: AsyncSequence {
+    typealias AsyncIterator = DataStreamIterator<Element>
+
+    private let iterator: DataStreamIterator<Element>
+
+    /// - Parameters:
+    ///   - dataProvider: A place we can read the data from
+    ///   - ranges: the byte ranges to read the data from
+    init?(dataProvider: any DataProvider<Element>, ranges: [ClosedRange<UInt>]) {
+        guard !ranges.isEmpty else { return nil }
+        self.iterator = DataStreamIterator<Element>(dataProvider: dataProvider, ranges: ranges)
+    }
+
+    func makeAsyncIterator() -> DataStreamIterator<Element> {
+        iterator
+    }
+}
+
+struct DataStreamIterator<Element>: AsyncIteratorProtocol {
+    private let dataProvider: any DataProvider<Element>
+    private var ranges: [ClosedRange<UInt>]
+
+    init(dataProvider: any DataProvider<Element>, ranges: [ClosedRange<UInt>]) {
+        self.dataProvider = dataProvider
+        self.ranges = ranges
+    }
+
+    mutating func next() async throws -> Element? {
+        guard !ranges.isEmpty else {
+            return nil
+        }
+        let range = ranges.removeFirst()
+        return await dataProvider.data(from: range.lowerBound, to: range.upperBound)
+    }
+}
+
+protocol DataProvider<Element> {
+    associatedtype Element
+
+    /// Returns a chunk of data
+    /// - Parameters:
+    ///   - start: range start
+    ///   - end: range end
+    /// - Returns: data chunk
+    func data(from start: UInt, to end: UInt) async -> Element?
+}

--- a/Model/ZimFileService/ZimContentProvider.swift
+++ b/Model/ZimFileService/ZimContentProvider.swift
@@ -1,0 +1,70 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+
+/// Async reading data in chunks via LibZim
+/// to be used with ``DataStream``
+struct ZimContentProvider: DataProvider {
+    
+    typealias Element = URLContent
+    private let url: URL
+
+    init(for url: URL) {
+        self.url = url
+    }
+
+    func data(from start: UInt, to end: UInt) async -> URLContent? {
+        return await withCheckedContinuation { continuation in
+            Task.detached(priority: .utility) {
+                let content = ZimFileService.shared.getURLContent(url: url, start: start, end: end)
+                continuation.resume(returning: content)
+            }
+        }
+    }
+}
+
+/// Async reading data in chunks directly from the file system
+/// to be used with ``DataStream``
+struct ZimDirectContentProvider: DataProvider {
+
+    typealias Element = URLContent
+    private let directAccess: DirectAccessInfo
+    private let contentSize: UInt
+
+    init(directAccess: DirectAccessInfo, contentSize: UInt) {
+        self.directAccess = directAccess
+        self.contentSize = contentSize
+    }
+
+    func data(from start: UInt, to end: UInt) async -> URLContent? {
+        return await withCheckedContinuation { continuation in
+            Task.detached(priority: .utility) {
+                let handle = FileHandle(forReadingAtPath: directAccess.path)
+                try? handle?.seek(toOffset: UInt64(directAccess.offset + start))
+                let dataLength = Int(min(contentSize - start, end - start + 1))
+                let data = handle?.readData(ofLength: dataLength)
+                try? handle?.close()
+                let urlContent: URLContent?
+                if let data {
+                    urlContent = URLContent(data: data, start: start, end: end)
+                } else {
+                    urlContent = nil
+                }
+                continuation.resume(returning: urlContent)
+            }
+        }
+    }
+}

--- a/Model/ZimFileService/ZimFileService.h
+++ b/Model/ZimFileService/ZimFileService.h
@@ -44,5 +44,7 @@
 - (NSNumber *_Nullable)getContentSize:(NSUUID *_Nonnull)zimFileID contentPath:(NSString *_Nonnull)contentPath NS_REFINED_FOR_SWIFT;
 - (NSDictionary *_Nullable)getContent:(NSUUID *_Nonnull)zimFileID contentPath:(NSString *_Nonnull)contentPath
                            start:(NSUInteger)start end:(NSUInteger)end NS_REFINED_FOR_SWIFT;
+- (NSDictionary *_Nullable)getMetaData:(NSUUID *_Nonnull)zimFileID contentPath:(NSString *_Nonnull)contentPath  NS_REFINED_FOR_SWIFT;
+- (NSDictionary *_Nullable)getDirectAccess: (NSUUID *_Nonnull)zimFileID contentPath:(NSString *_Nonnull)contentPath NS_REFINED_FOR_SWIFT;
 
 @end

--- a/Tests/ByteRangesTests.swift
+++ b/Tests/ByteRangesTests.swift
@@ -1,0 +1,50 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import XCTest
+@testable import Kiwix
+
+final class ByteRangesTests: XCTestCase {
+
+    func test_zero_values() {
+        XCTAssertEqual(ByteRanges.rangesFor(contentLength: 0, rangeSize: 2), [])
+        XCTAssertEqual(ByteRanges.rangesFor(contentLength: 1, rangeSize: 0), [])
+    }
+
+    func test_size_too_large() {
+        XCTAssertEqual(ByteRanges.rangesFor(contentLength: 1, rangeSize: 2), [0...0])
+        XCTAssertEqual(ByteRanges.rangesFor(contentLength: 5, rangeSize: 6), [0...4])
+    }
+
+    func test_size_one() {
+        XCTAssertEqual(ByteRanges.rangesFor(contentLength: 1, rangeSize: 1), [0...0])
+        XCTAssertEqual(ByteRanges.rangesFor(contentLength: 2, rangeSize: 1), [0...0, 1...1])
+        XCTAssertEqual(ByteRanges.rangesFor(contentLength: 3, rangeSize: 1), [0...0, 1...1, 2...2])
+    }
+
+    func test_size_two() {
+        XCTAssertEqual(ByteRanges.rangesFor(contentLength: 2, rangeSize: 2), [0...1])
+        XCTAssertEqual(ByteRanges.rangesFor(contentLength: 3, rangeSize: 2), [0...1, 2...2])
+        XCTAssertEqual(ByteRanges.rangesFor(contentLength: 4, rangeSize: 2), [0...1, 2...3])
+    }
+
+    func test_8_bits() {
+        XCTAssertEqual(ByteRanges.rangesFor(contentLength: 8, rangeSize: 8), [0...7])
+        XCTAssertEqual(ByteRanges.rangesFor(contentLength: 10, rangeSize: 8), [0...7, 8...9])
+        XCTAssertEqual(ByteRanges.rangesFor(contentLength: 16, rangeSize: 8), [0...7, 8...15])
+        XCTAssertEqual(ByteRanges.rangesFor(contentLength: 24, rangeSize: 8), [0...7, 8...15, 16...23])
+    }
+
+}

--- a/Tests/DataStreamTests.swift
+++ b/Tests/DataStreamTests.swift
@@ -1,0 +1,73 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import XCTest
+@testable import Kiwix
+
+final class DataStreamTests: XCTestCase {
+
+    func test_empty_data() async throws {
+        let data = Data()
+        XCTAssertNil(
+            DataStream(
+                dataProvider: MockDataProvider(data: data),
+                ranges: []
+            )
+        )
+    }
+
+    func test_small_data() async throws {
+        let data = "small test data".data(using: .utf8)!
+        let dataStream = DataStream(
+            dataProvider: MockDataProvider(data: data),
+            ranges: ByteRanges.rangesFor(contentLength: UInt(data.count),
+                                         rangeSize: 256)
+        )!
+        var outData = Data()
+        for try await subData in dataStream {
+            outData.append(subData)
+        }
+        XCTAssertEqual(data, outData)
+    }
+
+    func test_large_data() async throws {
+        var largeString = ""
+        let value = UUID().uuidString
+        for _ in 0...100_000 {
+            largeString.append(value)
+        }
+        let data = largeString.data(using: .utf8)!
+        let dataStream = DataStream(
+            dataProvider: MockDataProvider(data: data),
+            ranges: ByteRanges.rangesFor(contentLength: UInt(data.count),
+                                         rangeSize: 256)
+        )!
+        var outData = Data()
+        for try await subData in dataStream {
+            outData.append(subData)
+        }
+        XCTAssertEqual(data, outData)
+    }
+}
+
+private struct MockDataProvider: DataProvider {
+    typealias Element = Data
+    let data: Data
+
+    func data(from start: UInt, to end: UInt) async -> Data? {
+        let range = Range<Int>(uncheckedBounds: (Int(start), Int(end+1)))
+        return data.subdata(in: range)
+    }
+}


### PR DESCRIPTION
Fixes: #773 

Reading the content in "chunks".
Both direct and indirect / ZIM streaming data solution is added.
Currently the ZIM streaming is not in use, until the offset issue is resolved on the libZIM side (see https://github.com/openzim/libzim/issues/886).

There are still issues with syncing the urlScheme closing, and maybe it's worth to add a Task cancelation, when the user leaves the currently loading page.