### PR TITLE
793 supporting entries ending in "/"

### DIFF
--- a/Model/Utilities/String+Extension.swift
+++ b/Model/Utilities/String+Extension.swift
@@ -57,6 +57,11 @@ extension String {
         )
     }
 
+    func removingPrefix(_ value: String) -> String {
+        guard hasPrefix(value) else { return self }
+        return String(dropFirst(value.count))
+    }
+
     func replacingRegex(
         matching pattern: String,
         findingOptions: NSRegularExpression.Options = .caseInsensitive,

--- a/Model/Utilities/URL.swift
+++ b/Model/Utilities/URL.swift
@@ -48,6 +48,14 @@ extension URL {
     var isKiwixURL: Bool { schemeType == .kiwix }
     var isGeoURL: Bool { schemeType == .geo }
 
+    var contentPath: String {
+        [scheme, "://", host, "/"]
+            .compactMap { $0 }
+            .reduce(absoluteString) { partialResult, prefix in
+                partialResult.removingPrefix(prefix)
+            }
+    }
+
     // swiftlint:disable:next force_try
     static let documentDirectory = try! FileManager.default.url(
         for: .documentDirectory,

--- a/Model/Utilities/URL.swift
+++ b/Model/Utilities/URL.swift
@@ -48,6 +48,9 @@ extension URL {
     var isKiwixURL: Bool { schemeType == .kiwix }
     var isGeoURL: Bool { schemeType == .geo }
 
+    /// Returns the path, that should be used to resolve articles in ZIM files.
+    /// It makes sure that trailing slash is preserved,
+    /// and leading slash is removed.
     var contentPath: String {
         [scheme, "://", host, "/"]
             .compactMap { $0 }

--- a/Model/Utilities/URL.swift
+++ b/Model/Utilities/URL.swift
@@ -52,11 +52,18 @@ extension URL {
     /// It makes sure that trailing slash is preserved,
     /// and leading slash is removed.
     var contentPath: String {
-        [scheme, "://", host, "/"]
-            .compactMap { $0 }
-            .reduce(absoluteString) { partialResult, prefix in
-                partialResult.removingPrefix(prefix)
-            }
+        if #available(macOS 13.0, iOS 16.0, *) {
+            return path(percentEncoded: false).removingPrefix("/")
+        } else {
+            var path: String = [scheme, "://", host, "/"]
+                .compactMap { $0 }
+                .reduce(absoluteString) { partialResult, prefix in
+                    partialResult.removingPrefix(prefix)
+                }
+            path = path.removingPercentEncoding ?? path
+            path = (try? path.replacingRegex(matching: "#.*", with: "")) ?? path
+            return path
+        }
     }
 
     // swiftlint:disable:next force_try

--- a/Model/Utilities/URL.swift
+++ b/Model/Utilities/URL.swift
@@ -52,18 +52,7 @@ extension URL {
     /// It makes sure that trailing slash is preserved,
     /// and leading slash is removed.
     var contentPath: String {
-        if #available(macOS 13.0, iOS 16.0, *) {
-            return path(percentEncoded: false).removingPrefix("/")
-        } else {
-            var path: String = [scheme, "://", host, "/"]
-                .compactMap { $0 }
-                .reduce(absoluteString) { partialResult, prefix in
-                    partialResult.removingPrefix(prefix)
-                }
-            path = path.removingPercentEncoding ?? path
-            path = (try? path.replacingRegex(matching: "#.*", with: "")) ?? path
-            return path
-        }
+        path(percentEncoded: false).removingPrefix("/")
     }
 
     // swiftlint:disable:next force_try

--- a/Model/ZimFileService/ZimFileService.swift
+++ b/Model/ZimFileService/ZimFileService.swift
@@ -87,7 +87,7 @@ extension ZimFileService {
     func getRedirectedURL(url: URL) -> URL? {
         guard let zimFileID = url.host,
               let zimFileID = UUID(uuidString: zimFileID),
-              let redirectedPath = __getRedirectedPath(zimFileID, contentPath: url.path) else { return nil }
+              let redirectedPath = __getRedirectedPath(zimFileID, contentPath: url.contentPath) else { return nil }
         return URL(zimFileID: zimFileID.uuidString, contentPath: redirectedPath)
     }
 
@@ -107,24 +107,24 @@ extension ZimFileService {
 
     func getURLContent(url: URL) -> URLContent? {
         guard let zimFileID = url.host else { return nil }
-        return getURLContent(zimFileID: zimFileID, contentPath: url.path)
+        return getURLContent(zimFileID: zimFileID, contentPath: url.contentPath)
     }
 
     func getURLContent(url: URL, start: UInt, end: UInt) -> URLContent? {
         guard let zimFileID = url.host else { return nil }
-        return getURLContent(zimFileID: zimFileID, contentPath: url.path, start: start, end: end)
+        return getURLContent(zimFileID: zimFileID, contentPath: url.contentPath, start: start, end: end)
     }
 
     func getContentSize(url: URL) -> NSNumber? {
         guard let zimFileID = url.host,
               let zimFileUUID = UUID(uuidString: zimFileID) else { return nil }
-        return __getContentSize(zimFileUUID, contentPath: url.path)
+        return __getContentSize(zimFileUUID, contentPath: url.contentPath)
     }
 
     func getDirectAccessInfo(url: URL) -> DirectAccessInfo? {
         guard let zimFileID = url.host,
               let zimFileUUID = UUID(uuidString: zimFileID),
-              let directAccess = __getDirectAccess(zimFileUUID, contentPath: url.path),
+              let directAccess = __getDirectAccess(zimFileUUID, contentPath: url.contentPath),
               let path: String = directAccess["path"] as? String,
               let offset: UInt = directAccess["offset"] as? UInt
         else {
@@ -136,7 +136,7 @@ extension ZimFileService {
     func getContentMetaData(url: URL) -> URLContentMetaData? {
         guard let zimFileID = url.host,
               let zimFileUUID = UUID(uuidString: zimFileID),
-              let content = __getMetaData(zimFileUUID, contentPath: url.path),
+              let content = __getMetaData(zimFileUUID, contentPath: url.contentPath),
               let mime = content["mime"] as? String,
               let size = content["size"] as? UInt,
               let title = content["title"] as? String else { return nil }

--- a/Tests/URLContentPathTests.swift
+++ b/Tests/URLContentPathTests.swift
@@ -1,0 +1,44 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import XCTest
+@testable import Kiwix
+
+final class URLContentPathTests: XCTestCase {
+
+    private let testURLs = [
+        URL(string: "kiwix://6E4F3D4A-2F8A-789A-3B88-212219F4FB27/irp.fas.org/doddir/milmed/index.html")!,
+        URL(string: "kiwix://861C031F-DAFB-9688-4DB4-8F1199FE2926/mesquartierschinois.wordpress.com/")!
+    ]
+
+    func test_no_leading_slash() {
+        testURLs.forEach { url in
+            XCTAssertFalse(url.contentPath.first == "/")
+        }
+    }
+
+    func test_preserves_trailing_slash() {
+        let url = URL(string: "kiwix://861C031F-DAFB-9688-4DB4-8F1199FE2926/mesquartierschinois.wordpress.com/")!
+        XCTAssertEqual(url.contentPath.last, "/")
+    }
+
+    func test_value() {
+        XCTAssertEqual(testURLs.map { $0.contentPath }, [
+            "irp.fas.org/doddir/milmed/index.html",
+            "mesquartierschinois.wordpress.com/"
+        ])
+    }
+
+}

--- a/Tests/URLContentPathTests.swift
+++ b/Tests/URLContentPathTests.swift
@@ -20,7 +20,8 @@ final class URLContentPathTests: XCTestCase {
 
     private let testURLs = [
         URL(string: "kiwix://6E4F3D4A-2F8A-789A-3B88-212219F4FB27/irp.fas.org/doddir/milmed/index.html")!,
-        URL(string: "kiwix://861C031F-DAFB-9688-4DB4-8F1199FE2926/mesquartierschinois.wordpress.com/")!
+        URL(string: "kiwix://861C031F-DAFB-9688-4DB4-8F1199FE2926/mesquartierschinois.wordpress.com/")!,
+        URL(string: "kiwix://861C031F-DAFB-9688-4DB4-8F1199FE2926/widgets.wp.com/likes/master.html%3Fver%3D20240530#ver=20240530&lang=fr&lang_ver=1713167421&origin=https://mesquartierschinois.wordpress.com")!
     ]
 
     func test_no_leading_slash() {
@@ -37,7 +38,8 @@ final class URLContentPathTests: XCTestCase {
     func test_value() {
         XCTAssertEqual(testURLs.map { $0.contentPath }, [
             "irp.fas.org/doddir/milmed/index.html",
-            "mesquartierschinois.wordpress.com/"
+            "mesquartierschinois.wordpress.com/",
+            "widgets.wp.com/likes/master.html?ver=20240530"
         ])
     }
 


### PR DESCRIPTION
Fixes: #793 

Made sure that we suport urls to contentPath ending with "/",
we drop if there's any "#" symbol with additional arguments there (which was also failing).
Fixed the issue with the error pop-up, now only a failing "main" document should trigger the pop-up.

Tested with "Mes quartiers chinois":

<img width="1524" alt="Screenshot 2024-06-08 at 15 06 08" src="https://github.com/kiwix/kiwix-apple/assets/6784320/d3944b9a-09ab-4198-9e21-0e9af2ac1ee9">
