### PR TITLE
772 after resuming app ios video displayed black

### DIFF
--- a/Support/injection.js
+++ b/Support/injection.js
@@ -69,7 +69,7 @@ function refreshVideoState() {
     if (document.pictureInPictureElement != null) {
         return;
     }
-    $("video").each(function(i) {
+    $("video").each(function(_) {
         if (this.paused && this.currentTime > 0) {
             this.play();
             this.pause();

--- a/Support/injection.js
+++ b/Support/injection.js
@@ -69,7 +69,7 @@ function refreshVideoState() {
     if (document.pictureInPictureElement != null) {
         return;
     }
-    $("video").each(function(_) {
+    $("video").each(function() {
         if (this.paused && this.currentTime > 0) {
             this.play();
             this.pause();

--- a/Support/injection.js
+++ b/Support/injection.js
@@ -63,3 +63,16 @@ function scrollToHeading(id) {
 	element = document.getElementById(id)
 	element.scrollIntoView({block: 'start', inline: 'start', behavior: 'smooth'})
 }
+
+function refreshVideoState() {
+    // make sure it's not in picture in picture mode:
+    if (document.pictureInPictureElement != null) {
+        return;
+    }
+    $("video").each(function(i) {
+        if (this.paused && this.currentTime > 0) {
+            this.play();
+            this.pause();
+        }
+    });
+}

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -238,6 +238,16 @@ final class BrowserViewModel: NSObject, ObservableObject,
         }
     }
 
+    // MARK: - Video fixes
+    @MainActor
+    func refreshVideoState() {
+        Task {
+            await MainActor.run {
+                webView.evaluateJavaScript("refreshVideoState();")
+            }
+        }
+    }
+
     // MARK: - New Tab Creation
 
 #if os(macOS)

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -61,6 +61,7 @@ struct BrowserTab: View {
         }
         .onAppear {
             browser.updateLastOpened()
+            browser.refreshVideoState()
         }
         .onDisappear {
             browser.onDisappear()


### PR DESCRIPTION
Fixes: #772 

Note: So far I only found this "hacky" javascript solution to fix this issue.
The traditional "low memory" warning triggers are not called in this case, therefore this black screen side effect is not due to that.
By playing and pausing the video (one after another) fixes this.
The fix is applied if:
- we are not in picture in picture mode - here we do not have this problem
- we are not at the beginning of the video - here we also do not have this problem, plus if we apply it as we come back to the tab., it will change the "poster" of the video to the first frame of the video (which might be black)