### PR TITLE
Fix javascript console errors

### DIFF
--- a/Support/injection.js
+++ b/Support/injection.js
@@ -31,7 +31,10 @@ let observer = new IntersectionObserver(function(entries) {
 // register scroll view to handle heading on top of the page
 window.onscroll = function() {
 	if (document.documentElement.scrollTop <= 0) {
-		window.webkit.messageHandlers.headingVisible.postMessage({id: headings[0].id})
+		const headingVisible = window.webkit.messageHandlers.headingVisible
+		if(headingVisible !== undefined && headingVisible.postMessage !== undefined) {
+			headingVisible.postMessage({id: headings[0].id})
+		}
 	}
 }
 


### PR DESCRIPTION
Fix javascript console log errors.
Depending on the content the ``messageHandlers.headingVisible`` might or might not be available.

