### PR TITLE
Improved data for bookmark creation

### DIFF
--- a/Model/Entities/Entities.swift
+++ b/Model/Entities/Entities.swift
@@ -170,6 +170,10 @@ struct URLContentMetaData {
     var isTextType: Bool {
         mime.hasPrefix("text/")
     }
+
+    var isPDFType: Bool {
+        mime.hasSuffix("/pdf")
+    }
 }
 
 struct URLContent {


### PR DESCRIPTION
Fixes #827

We could possibly improve on collecting the data that is needed to create a bookmark for PDF.
By using a PDF parser, we can find a possible snippet to be used (first sentence parsed out).
So far the overall outcome is highly dependent on the PDF content, with these changes we can achieve the following:

<img width="1142" alt="Screenshot 2024-06-22 at 11 43 49" src="https://github.com/kiwix/kiwix-apple/assets/6784320/56e9b98d-368c-4272-9f9a-cd5964c554f8">
