### PR TITLE
Remove Bookmark image and snippet

### DIFF
--- a/Model/Entities/Entities.swift
+++ b/Model/Entities/Entities.swift
@@ -21,9 +21,7 @@ class Bookmark: NSManagedObject, Identifiable {
     var id: URL { articleURL }
 
     @NSManaged var articleURL: URL
-    @NSManaged var thumbImageURL: URL?
     @NSManaged var title: String
-    @NSManaged var snippet: String?
     @NSManaged var created: Date
 
     @NSManaged var zimFile: ZimFile?

--- a/Support/de.lproj/Localizable.strings
+++ b/Support/de.lproj/Localizable.strings
@@ -53,7 +53,6 @@
 "external_link_handler.alert.not_loading.description" = "Ein externer Link wird aktiviert. Ihre aktuelle Einstellung lässt jedoch das Öffnen nicht zu.";
 "file_import.alert.no_open.title" = "Kann Datei nicht öffnen";
 "file_import.alert.no_open.message" = "%@ kann nicht geöffnet werden.";
-"article_cell.no_snippet.label" = "Kein Treffer";
 "attribute.detail.unknown" = "Unbekannt";
 "download_task_cell.status.failed" = "Fehlgeschlagen";
 "download_task_cell.status.downloading" = "Herunterladen …";

--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -77,7 +77,6 @@
 "file_import.alert.no_open.title" = "Unable to open file";
 "file_import.alert.no_open.message" = "%@ cannot be opened.";
 
-"article_cell.no_snippet.label" = "No snippet";
 "attribute.detail.unknown" = "Unknown";
 
 "download_task_cell.status.failed" = "Failed";

--- a/Support/fr.lproj/Localizable.strings
+++ b/Support/fr.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "external_link_handler.alert.not_loading.description" = "Un lien externe est tapé. Toutefois, votre paramétrage actuel ne permet pas de le charger.";
 "file_import.alert.no_open.title" = "Impossible d’ouvrir le fichier !";
 "file_import.alert.no_open.message" = "%@ ne peut pas être ouvert.";
-"article_cell.no_snippet.label" = "Aucun extrait";
 "attribute.detail.unknown" = "Inconnu";
 "download_task_cell.status.failed" = "Échec";
 "download_task_cell.status.downloading" = "Téléchargement...";

--- a/Support/ha.lproj/Localizable.strings
+++ b/Support/ha.lproj/Localizable.strings
@@ -51,7 +51,6 @@
 "external_link_handler.alert.not_loading.description" = "An buga hanyar haɗi ta waje. Koyaya, saitin ku na yanzu ba ya ba da izinin ɗora shi.";
 "file_import.alert.no_open.title" = "Rashin iya buɗe fayil";
 "file_import.alert.no_open.message" = "%@ ba za a iya buɗewa ba.";
-"article_cell.no_snippet.label" = "Babu wani sashi";
 "attribute.detail.unknown" = "Ba a sani ba";
 "download_task_cell.status.failed" = "fadi";
 "download_task_cell.status.downloading" = "Saukowa...";

--- a/Support/he.lproj/Localizable.strings
+++ b/Support/he.lproj/Localizable.strings
@@ -53,7 +53,6 @@
 "external_link_handler.alert.not_loading.description" = "נלחץ קישור חיצוני. עם זאת, ההגדרה הנוכחית שלך לא מאפשרת לטעון אותו.";
 "file_import.alert.no_open.title" = "לא ניתן לפתוח את הקובץ";
 "file_import.alert.no_open.message" = "לא ניתן לפתוח את %@.";
-"article_cell.no_snippet.label" = "אין קטע גזור";
 "attribute.detail.unknown" = "לא ידוע";
 "download_task_cell.status.failed" = "נכשל";
 "download_task_cell.status.downloading" = "בהורדה...";

--- a/Support/ia.lproj/Localizable.strings
+++ b/Support/ia.lproj/Localizable.strings
@@ -52,7 +52,6 @@
 "external_link_handler.alert.not_loading.description" = "Un ligamine externe ha essite toccate, ma tu configuration actual non permitte cargar lo.";
 "file_import.alert.no_open.title" = "Impossibile aperir le file";
 "file_import.alert.no_open.message" = "%@ non pote esser aperite.";
-"article_cell.no_snippet.label" = "Necun extracto";
 "attribute.detail.unknown" = "Incognite";
 "download_task_cell.status.failed" = "Fallite";
 "download_task_cell.status.downloading" = "Discargamento…";

--- a/Support/ig.lproj/Localizable.strings
+++ b/Support/ig.lproj/Localizable.strings
@@ -51,7 +51,6 @@
 "external_link_handler.alert.not_loading.description" = "E nwere nkokọ mpụga. Otú ọ dịla, ọnọdụ nhazị gị ugbu a anaghị ekwe ka a na-ebudata ya";
 "file_import.alert.no_open.title" = "Enweghị ike imepe faịlụ zim";
 "file_import.alert.no_open.message" = "Enweghị ike imeghe %@.";
-"article_cell.no_snippet.label" = "Enweghị snippet";
 "attribute.detail.unknown" = "Nke amaghị";
 "download_task_cell.status.failed" = "ọ gaghị";
 "download_task_cell.status.downloading" = "Na-ebudata...";

--- a/Support/mk.lproj/Localizable.strings
+++ b/Support/mk.lproj/Localizable.strings
@@ -52,7 +52,6 @@
 "external_link_handler.alert.not_loading.description" = "Допрена е надворешна врска. Сепак, вашата моментална поставка не ѝ дозволува да се вчита.";
 "file_import.alert.no_open.title" = "Не можам да ја отворам податотеката";
 "file_import.alert.no_open.message" = "%@ не може да се отвори.";
-"article_cell.no_snippet.label" = "Нема исечок";
 "attribute.detail.unknown" = "Непознато";
 "download_task_cell.status.failed" = "Неуспешно";
 "download_task_cell.status.downloading" = "Преземам...";

--- a/Support/ru.lproj/Localizable.strings
+++ b/Support/ru.lproj/Localizable.strings
@@ -57,7 +57,6 @@
 "external_link_handler.alert.not_loading.description" = "Внешняя ссылка прослушивается. Однако ваши текущие настройки не позволяют его загрузить.";
 "file_import.alert.no_open.title" = "Невозможно открыть файл";
 "file_import.alert.no_open.message" = "%@ невозможно открыть.";
-"article_cell.no_snippet.label" = "Нет фрагмента";
 "attribute.detail.unknown" = "Неизвестно";
 "download_task_cell.status.failed" = "Не удалось";
 "download_task_cell.status.downloading" = "Загрузка...";

--- a/Support/sl.lproj/Localizable.strings
+++ b/Support/sl.lproj/Localizable.strings
@@ -46,7 +46,6 @@
 "external_link_handler.alert.not_loading.description" = "Tapnjena je bila zunanja povezava, vendar vam trenutna nastavitev ne omogoča njenega prenosa.";
 "file_import.alert.no_open.title" = "Datoteke ni mogoče odpreti";
 "file_import.alert.no_open.message" = "%@ ni mogoče odpreti.";
-"article_cell.no_snippet.label" = "Ni delčka";
 "attribute.detail.unknown" = "Neznano";
 "download_task_cell.status.failed" = "Spodletelo";
 "download_task_cell.status.downloading" = "Prenašam ...";

--- a/Support/sv.lproj/Localizable.strings
+++ b/Support/sv.lproj/Localizable.strings
@@ -55,7 +55,6 @@
 "external_link_handler.alert.not_loading.description" = "En extern länk har tryckts. Men dina nuvarande inställningar tillåter inte att länken laddas in.";
 "file_import.alert.no_open.title" = "Kunde inte öppna filen";
 "file_import.alert.no_open.message" = "%@ kan inte öppnas.";
-"article_cell.no_snippet.label" = "Inget utdrag";
 "attribute.detail.unknown" = "Okänd";
 "download_task_cell.status.failed" = "Misslyckades";
 "download_task_cell.status.downloading" = "Laddar ned...";

--- a/Support/tr.lproj/Localizable.strings
+++ b/Support/tr.lproj/Localizable.strings
@@ -47,7 +47,6 @@
 "external_link_handler.alert.not_loading.description" = "Harici bir bağlantıya tıklanıldı ancak mevcut ayarınız bunun yüklenmesine izin vermiyor.";
 "file_import.alert.no_open.title" = "Dosya açılamıyor";
 "file_import.alert.no_open.message" = "%@ açılamadı";
-"article_cell.no_snippet.label" = "Parçacık yok";
 "attribute.detail.unknown" = "Bilinmiyor";
 "download_task_cell.status.failed" = "Başarısız";
 "download_task_cell.status.downloading" = "Yükleniyor...";

--- a/Support/zh-hans.lproj/Localizable.strings
+++ b/Support/zh-hans.lproj/Localizable.strings
@@ -55,7 +55,6 @@
 "external_link_handler.alert.not_loading.description" = "已点击外部链接。但您当前的设置不允许加载该链接。";
 "file_import.alert.no_open.title" = "无法打开文件";
 "file_import.alert.no_open.message" = "无法打开 %@。";
-"article_cell.no_snippet.label" = "无片段";
 "attribute.detail.unknown" = "未知";
 "download_task_cell.status.failed" = "失败";
 "download_task_cell.status.downloading" = "正在下载...";

--- a/Support/zh-hant.lproj/Localizable.strings
+++ b/Support/zh-hant.lproj/Localizable.strings
@@ -53,7 +53,6 @@
 "external_link_handler.alert.not_loading.description" = "有點擊到外部連結，但是您目前的設定不允許載入該連結。";
 "file_import.alert.no_open.title" = "無法開啟檔案";
 "file_import.alert.no_open.message" = "無法開啟%@。";
-"article_cell.no_snippet.label" = "沒有片段";
 "attribute.detail.unknown" = "不明";
 "download_task_cell.status.failed" = "失敗";
 "download_task_cell.status.downloading" = "正在下載…";

--- a/SwiftUI/Model/DataModel.xcdatamodeld/DataModel.xcdatamodel/contents
+++ b/SwiftUI/Model/DataModel.xcdatamodeld/DataModel.xcdatamodel/contents
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22F66" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Bookmark" representedClassName=".Bookmark" syncable="YES">
         <attribute name="articleURL" attributeType="URI"/>
         <attribute name="created" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="snippet" optional="YES" attributeType="String" spotlightIndexingEnabled="YES"/>
-        <attribute name="thumbImageURL" optional="YES" attributeType="URI"/>
         <attribute name="title" attributeType="String" spotlightIndexingEnabled="YES"/>
         <relationship name="zimFile" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ZimFile" inverseName="bookmarks" inverseEntity="ZimFile"/>
         <uniquenessConstraints>

--- a/SwiftUI/Model/ZimMigration.swift
+++ b/SwiftUI/Model/ZimMigration.swift
@@ -68,7 +68,6 @@ enum ZimMigration {
             if let newArticleURL = bookmark.articleURL.updateHost(to: newHost) {
                 bookmark.articleURL = newArticleURL
             }
-            bookmark.thumbImageURL = bookmark.thumbImageURL?.updateHost(to: newHost)
         }
         fromZim.tabs.forEach { (tab: Tab) in
             tab.zimFile = toZim

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -614,6 +614,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
 
     func createBookmark(url: URL? = nil) {
         guard let url = url ?? webView.url else { return }
+        let title = webView.title
         Database.performBackgroundTask { context in
             let bookmark = Bookmark(context: context)
             bookmark.articleURL = url
@@ -623,16 +624,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
                   let metaData = ZimFileService.shared.getContentMetaData(url: url) else { return }
 
             bookmark.zimFile = zimFile
-            if metaData.isTextType,
-               let parser = try? HTMLParser(url: url) {
-                bookmark.title = parser.title ?? metaData.zimTitle
-                if let imagePath = parser.getFirstImagePath() {
-                    bookmark.thumbImageURL = URL(zimFileID: zimFileID.uuidString, contentPath: imagePath)
-                }
-                bookmark.snippet = parser.getFirstSentence(languageCode: nil)?.string
-            } else {
-                bookmark.title = metaData.zimTitle
-            }
+            bookmark.title = title ?? metaData.zimTitle
             try? context.save()
         }
     }

--- a/Views/Bookmarks.swift
+++ b/Views/Bookmarks.swift
@@ -78,9 +78,6 @@ struct Bookmarks: View {
 
     private static func buildPredicate(searchText: String) -> NSPredicate? {
         guard !searchText.isEmpty else { return nil }
-        return NSCompoundPredicate(orPredicateWithSubpredicates: [
-            NSPredicate(format: "title CONTAINS[cd] %@", searchText),
-            NSPredicate(format: "snippet CONTAINS[cd] %@", searchText)
-        ])
+        return NSPredicate(format: "title CONTAINS[cd] %@", searchText)
     }
 }

--- a/Views/BuildingBlocks/ArticleCell.swift
+++ b/Views/BuildingBlocks/ArticleCell.swift
@@ -22,24 +22,17 @@ struct ArticleCell: View {
     let title: String
     let snippet: NSAttributedString?
     let zimFile: ZimFile?
-    let alwaysShowSnippet: Bool
 
     init(bookmark: Bookmark) {
         self.title = bookmark.title
-        if let snippet = bookmark.snippet {
-            self.snippet = NSAttributedString(string: snippet)
-        } else {
-            self.snippet = nil
-        }
+        self.snippet = nil
         self.zimFile = bookmark.zimFile
-        self.alwaysShowSnippet = true
     }
 
     init(result: SearchResult, zimFile: ZimFile?) {
         self.title = result.title
         self.snippet = result.snippet
         self.zimFile = zimFile
-        self.alwaysShowSnippet = false
     }
 
     var body: some View {
@@ -50,8 +43,6 @@ struct ArticleCell: View {
                 Group {
                     if let snippet = snippet {
                         Text(AttributedString(snippet)).lineLimit(4)
-                    } else if alwaysShowSnippet {
-                        Text("article_cell.no_snippet.label".localized).foregroundColor(.secondary)
                     }
                 }.font(.caption).multilineTextAlignment(.leading)
                 Spacer(minLength: 0)


### PR DESCRIPTION
Here is the impact of removing the snippets and the image URL from the bookmarks.

The code is somewhat simpler. The HTML parser is still in use by the search results (I am not sure if that's needed btw), therefore that cannot be removed yet.

## Screenshots before / after on all devices:


# iPhone

![Screenshot 2024-06-22 at 22 05 26](https://github.com/kiwix/kiwix-apple/assets/6784320/d3207b46-01f7-4f01-875a-6ccc1a0cead7)
----------------------------------------
----------------------------------------

![Screenshot 2024-06-22 at 22 20 46](https://github.com/kiwix/kiwix-apple/assets/6784320/46ad055a-3c93-4d01-8870-410fa75b5654)



# iPad

![Screenshot 2024-06-22 at 21 58 24](https://github.com/kiwix/kiwix-apple/assets/6784320/bf899daf-3c08-4e5b-9a3a-fd692fbdaac7)
----------------------------------------
----------------------------------------

![Screenshot 2024-06-22 at 22 22 47](https://github.com/kiwix/kiwix-apple/assets/6784320/585983ee-9c28-48b0-a023-318fe34cd168)



# mac
<img width="899" alt="Screenshot 2024-06-22 at 21 53 24" src="https://github.com/kiwix/kiwix-apple/assets/6784320/6110f0cb-2059-4d35-812e-5dcef55ef5ce">


----------------------------------------
----------------------------------------

<img width="1088" alt="Screenshot 2024-06-22 at 14 25 39" src="https://github.com/kiwix/kiwix-apple/assets/6784320/86f8fd7b-a954-43b1-9140-e67ae17ffe44">

