### PR TITLE
Fix tab cell recycle, and favicon look for dark mode

### DIFF
--- a/Views/BuildingBlocks/Favicon.swift
+++ b/Views/BuildingBlocks/Favicon.swift
@@ -28,10 +28,7 @@ struct Favicon: View {
     }
 
     var body: some View {
-        ZStack(alignment: .center) {
-            Color.white.clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
-            image.scaledToFit().cornerRadius(2).padding(1)
-        }
+        image.scaledToFit().cornerRadius(3)
         .aspectRatio(1, contentMode: .fit)
         .onAppear {
             guard let imageURL = imageURL, imageData == nil else { return }


### PR DESCRIPTION
Fixes: #831 

Apart from fixing the warning issue (see #831),  the look and feel of the icons are improved, especially in Dark Mode.

# BEFORE

![Screenshot 2024-06-23 at 13 30 41](https://github.com/kiwix/kiwix-apple/assets/6784320/cd7d4c85-2ef2-4e63-8627-5eb892dba407)
![Screenshot 2024-06-23 at 13 30 51](https://github.com/kiwix/kiwix-apple/assets/6784320/e78415dc-78ba-4961-bd1f-3fb20f97beee)


# AFTER

![Screenshot 2024-06-23 at 13 47 18](https://github.com/kiwix/kiwix-apple/assets/6784320/e8beb07b-41f3-4360-8756-4457229b3a74)
![Screenshot 2024-06-23 at 13 47 32](https://github.com/kiwix/kiwix-apple/assets/6784320/022df297-5103-4bff-9e90-57b02d57bdc1)

