### PR TITLE
869 no book found line for lowtech

### DIFF
--- a/Model/Entities/ZimFileMetaData/ZimFileMetaData.h
+++ b/Model/Entities/ZimFileMetaData/ZimFileMetaData.h
@@ -46,4 +46,25 @@
 // methods
 - (nullable instancetype)initWithBook:(nonnull void *)book;
 
+- (nonnull instancetype)initWithFileID:(NSUUID * _Nonnull)fileID
+                        groupIdentifier:(NSString * _Nonnull)groupIdentifier
+                                  title:(NSString * _Nonnull)title
+                        fileDescription:(NSString * _Nonnull)fileDescription
+                          languageCodes:(NSString * _Nonnull)languageCodes
+                               category:(NSString * _Nonnull)category
+                           creationDate:(NSDate * _Nonnull)creationDate
+                                   size:(NSNumber * _Nonnull)size
+                           articleCount:(NSNumber * _Nonnull)articleCount
+                             mediaCount:(NSNumber * _Nonnull)mediaCount
+                                creator:(NSString * _Nonnull)creator
+                              publisher:(NSString * _Nonnull)publisher
+                            downloadURL:(NSURL * _Nullable)downloadURL
+                             faviconURL:(NSURL * _Nullable)faviconURL
+                            faviconData:(NSData * _Nullable)faviconData
+                                 flavor:(NSString * _Nullable)flavor
+                             hasDetails:(BOOL)hasDetails
+                            hasPictures:(BOOL)hasPictures
+                              hasVideos:(BOOL)hasVideos
+                 requiresServiceWorkers:(BOOL)requiresServiceWorkers;
+
 @end

--- a/Model/Entities/ZimFileMetaData/ZimFileMetaData.mm
+++ b/Model/Entities/ZimFileMetaData/ZimFileMetaData.mm
@@ -70,6 +70,53 @@
     return self;
 }
 
+- (nonnull instancetype)initWithFileID:(NSUUID * _Nonnull)fileID
+                       groupIdentifier:(NSString * _Nonnull)groupIdentifier
+                                 title:(NSString * _Nonnull)title
+                       fileDescription:(NSString * _Nonnull)fileDescription
+                         languageCodes:(NSString * _Nonnull)languageCodes
+                              category:(NSString * _Nonnull)category
+                          creationDate:(NSDate * _Nonnull)creationDate
+                                  size:(NSNumber * _Nonnull)size
+                          articleCount:(NSNumber * _Nonnull)articleCount
+                            mediaCount:(NSNumber * _Nonnull)mediaCount
+                               creator:(NSString * _Nonnull)creator
+                             publisher:(NSString * _Nonnull)publisher
+                           downloadURL:(NSURL * _Nullable)downloadURL
+                            faviconURL:(NSURL * _Nullable)faviconURL
+                           faviconData:(NSData * _Nullable)faviconData
+                                flavor:(NSString * _Nullable)flavor
+                            hasDetails:(BOOL)hasDetails
+                           hasPictures:(BOOL)hasPictures
+                             hasVideos:(BOOL)hasVideos
+                requiresServiceWorkers:(BOOL)requiresServiceWorkers {
+
+    self = [super init];
+    if (self) {
+        _fileID = fileID;
+        _groupIdentifier = groupIdentifier;
+        _title = title;
+        _fileDescription = fileDescription;
+        _languageCodes = languageCodes;
+        _category = category;
+        _creationDate = creationDate;
+        _size = size;
+        _articleCount = articleCount;
+        _mediaCount = mediaCount;
+        _creator = creator;
+        _publisher = publisher;
+        _downloadURL = downloadURL;
+        _faviconURL = faviconURL;
+        _faviconData = faviconData;
+        _flavor = flavor;
+        _hasDetails = hasDetails;
+        _hasPictures = hasPictures;
+        _hasVideos = hasVideos;
+        _requiresServiceWorkers = requiresServiceWorkers;
+    }
+    return self;
+}
+
 - (NSString *)getLanguageCodesFromBook:(kiwix::Book *)book {
     NSString* string = [NSString stringWithUTF8String:book->getCommaSeparatedLanguages().c_str()];
     NSArray* components = [string componentsSeparatedByString: @","];

--- a/Tests/CategoryFetchingTests.swift
+++ b/Tests/CategoryFetchingTests.swift
@@ -72,7 +72,7 @@ final class CategoryFetchingTests: XCTestCase {
         request.predicate = ZimFilesCategory.buildPredicate(
             category: .other,
             searchText: "",
-            languageCodes: Set(["eng","deu","fra","ita","por"])
+            languageCodes: Set(["eng", "deu", "fra", "ita", "por"])
         )
         let results = try! context.fetch(request)
         XCTAssertEqual(results.count, 1)
@@ -108,7 +108,7 @@ final class CategoryFetchingTests: XCTestCase {
         request.predicate = ZimFilesCategory.buildPredicate(
             category: .other,
             searchText: "",
-            languageCodes: Set(["nld","por","fra"])
+            languageCodes: Set(["nld", "por", "fra"])
         )
         let results = try! context.fetch(request)
         XCTAssertEqual(results.count, 1)
@@ -126,7 +126,7 @@ final class CategoryFetchingTests: XCTestCase {
         request.predicate = ZimFilesCategory.buildPredicate(
             category: .other,
             searchText: "",
-            languageCodes: Set(["por","pol","ara","vie","kor"])
+            languageCodes: Set(["por", "pol", "ara", "vie", "kor"])
         )
         let results = try! context.fetch(request)
         XCTAssertTrue(results.isEmpty)
@@ -135,7 +135,6 @@ final class CategoryFetchingTests: XCTestCase {
     private func resetDB() throws {
         _ = try Database.viewContext.execute(NSBatchDeleteRequest(fetchRequest: NSFetchRequest(entityName: ZimFile.entity().name!)))
     }
-
 
 }
 

--- a/Tests/CategoryFetchingTests.swift
+++ b/Tests/CategoryFetchingTests.swift
@@ -1,0 +1,95 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import CoreData
+import XCTest
+import SwiftUI
+@testable import Kiwix
+
+final class CategoryFetchingTests: XCTestCase {
+
+    func testSingleZIMIsFilteredOutByLanguage() throws {
+        // insert a zimFile
+        let context = Database.viewContext
+        let zimFile = ZimFile(context: context)
+        let metadata = ZimFileMetaData.mock(languageCodes: "en", category: Category.other.rawValue)
+        LibraryOperations.configureZimFile(zimFile, metadata: metadata)
+        try? context.save()
+        let request = NSFetchRequest<ZimFile>(entityName: ZimFile.entity().name!)
+        request.predicate = ZimFilesCategory.buildPredicate(category: .other, searchText: "", languageCodes: Set(["xx"]))
+        let results = try! context.fetch(request)
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testSingleZIMCanBeFoundByLanguage() throws {
+        // insert a zimFile
+        let context = Database.viewContext
+        let zimFile = ZimFile(context: context)
+        let metadata = ZimFileMetaData.mock(languageCodes: "en", category: Category.other.rawValue)
+        LibraryOperations.configureZimFile(zimFile, metadata: metadata)
+        try? context.save()
+        let request = NSFetchRequest<ZimFile>(entityName: ZimFile.entity().name!)
+        request.predicate = ZimFilesCategory.buildPredicate(category: .other, searchText: "", languageCodes: Set(["en"]))
+        let results = try! context.fetch(request)
+        XCTAssertEqual(results.count, 1)
+    }
+
+}
+
+private extension ZimFileMetaData {
+    static func mock(fileID: UUID = UUID(),
+                     groupIdentifier: String = "test_group_id",
+                     title: String = "test ZIM title",
+                     fileDescription: String = "test description for test ZIM file",
+                     languageCodes: String,
+                     category: String = "other",
+                     creationDate: Date = .init(timeIntervalSince1970: 0),
+                     size: UInt = 1_234,
+                     articleCount: UInt = 99,
+                     mediaCount: UInt = 33,
+                     creator: String = "unit_test_creator",
+                     publisher: String = "unit_test_publisher",
+                     hasDetails: Bool = false,
+                     hasPictures: Bool = false,
+                     hasVideos: Bool = false,
+                     requiresServiceWorkers: Bool = false,
+                     downloadURL: URL? = nil,
+                     faviconURL: URL? = nil,
+                     faviconData: Data? = nil,
+                     flavor: String? = nil) -> ZimFileMetaData {
+        ZimFileMetaData(
+            fileID: fileID,
+            groupIdentifier: groupIdentifier,
+            title: title,
+            fileDescription: fileDescription,
+            languageCodes: languageCodes,
+            category: category,
+            creationDate: creationDate,
+            size: NSNumber(value: size),
+            articleCount: NSNumber(value: articleCount),
+            mediaCount: NSNumber(value: mediaCount),
+            creator: creator,
+            publisher: publisher,
+            downloadURL: downloadURL,
+            faviconURL: faviconURL,
+            faviconData: faviconData,
+            flavor: flavor,
+            hasDetails: hasDetails,
+            hasPictures: hasPictures,
+            hasVideos: hasVideos,
+            requiresServiceWorkers: requiresServiceWorkers
+        )
+    }
+}

--- a/Tests/CategoryFetchingTests.swift
+++ b/Tests/CategoryFetchingTests.swift
@@ -18,6 +18,7 @@ import XCTest
 import SwiftUI
 @testable import Kiwix
 
+// swiftlint:disable force_try
 final class CategoryFetchingTests: XCTestCase {
 
     override func setUpWithError() throws {
@@ -133,7 +134,11 @@ final class CategoryFetchingTests: XCTestCase {
     }
 
     private func resetDB() throws {
-        _ = try Database.viewContext.execute(NSBatchDeleteRequest(fetchRequest: NSFetchRequest(entityName: ZimFile.entity().name!)))
+        _ = try Database.viewContext.execute(
+            NSBatchDeleteRequest(
+                fetchRequest: NSFetchRequest(entityName: ZimFile.entity().name!)
+            )
+        )
     }
 
 }
@@ -183,3 +188,4 @@ private extension ZimFileMetaData {
         )
     }
 }
+// swiftlint:enable force_try

--- a/Views/Library/ZimFilesCategories.swift
+++ b/Views/Library/ZimFilesCategories.swift
@@ -70,10 +70,14 @@ struct ZimFilesCategory: View {
         }
     }
 
-    static func buildPredicate(category: Category, searchText: String) -> NSPredicate {
+    static func buildPredicate(
+        category: Category,
+        searchText: String,
+        languageCodes: Set<String> = Defaults[.libraryLanguageCodes]
+    ) -> NSPredicate {
         var predicates = [
             NSPredicate(format: "category == %@", category.rawValue),
-            NSPredicate(format: "languageCode IN %@", Defaults[.libraryLanguageCodes]),
+            NSPredicate(format: "languageCode IN %@", languageCodes),
             NSPredicate(format: "requiresServiceWorkers == false")
         ]
         if !searchText.isEmpty {

--- a/Views/Library/ZimFilesCategories.swift
+++ b/Views/Library/ZimFilesCategories.swift
@@ -75,9 +75,13 @@ struct ZimFilesCategory: View {
         searchText: String,
         languageCodes: Set<String> = Defaults[.libraryLanguageCodes]
     ) -> NSPredicate {
+        let langPredicates = languageCodes.map { langCode -> NSPredicate in
+            let regex = String(format: "(.*,)?%@(,.*)?", langCode)
+            return NSPredicate(format: "languageCode MATCHES %@", regex)
+        }
         var predicates = [
             NSPredicate(format: "category == %@", category.rawValue),
-            NSPredicate(format: "languageCode IN %@", languageCodes),
+            NSCompoundPredicate(orPredicateWithSubpredicates: langPredicates),
             NSPredicate(format: "requiresServiceWorkers == false")
         ]
         if !searchText.isEmpty {


### PR DESCRIPTION
Fixes: #869


It turned out that the low-tech ZIM is available in multiple languages.
We do support multiple user languages, according to which we filter the content.

Matching these 2 lists were not fully working. Multiple user selected content languages could match a ZIM if it was on the list of user languages. It wasn't working the other way around. Eg. user has "fra" only selected, and the ZIM has multiple languages according to the feed: "eng,fra,deu,nld,spa,ita,por,pol,ara,vie,kor", the former selection could not find it.

With the updated query now we can create multi to multi matching queries, and the missing ZIM items will show up.

The remanning changes were needed to make things testable.
