### PR TITLE
Fix Find in page availability

### DIFF
--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -212,7 +212,7 @@ private struct Content: View {
                        systemImage: "die.face.5",
                        action: { browser.loadRandomArticle() })
                 .disabled(zimFiles.isEmpty)
-                ContentSearchButton(webView: browser.webView)
+                ContentSearchButton()
             }
         }
     }

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -43,7 +43,7 @@ struct BrowserTab: View {
                 #endif
                 BookmarkButton()
                 #if os(iOS)
-                ContentSearchButton(webView: browser.webView)
+                ContentSearchButton()
                 #endif
                 ArticleShortcutButtons(displayMode: .mainAndRandomArticle)
             }

--- a/Views/BuildingBlocks/ContentSearchButton.swift
+++ b/Views/BuildingBlocks/ContentSearchButton.swift
@@ -19,16 +19,16 @@ import WebKit
 
 struct ContentSearchButton: View {
 
-    let webView: WKWebView
+    @EnvironmentObject private var browser: BrowserViewModel
 
     var body: some View {
         Button("common.search".localized,
                systemImage: "text.magnifyingglass",
                action: {
-            webView.isFindInteractionEnabled = true
-            webView.findInteraction?.presentFindNavigator(showingReplace: false)
+            browser.webView.isFindInteractionEnabled = true
+            browser.webView.findInteraction?.presentFindNavigator(showingReplace: false)
         }
-        ).disabled(webView.url == nil)
+        ).disabled(browser.url == nil)
     }
 }
 #endif


### PR DESCRIPTION
Fixes: #79 

The UI binding wasn't correct, as with the new tab a new WebView is created, and this feature was bound to the old instance, therefore the button remained disabled.