### PR TITLE
Enable OPDS invalid data input test-case

### DIFF
--- a/Tests/OPDSParserTests.swift
+++ b/Tests/OPDSParserTests.swift
@@ -17,9 +17,7 @@ import XCTest
 @testable import Kiwix
 
 final class OPDSParserTests: XCTestCase {
-    /// Test OPDSParser.parse throws error when OPDS data is invalid.
     func testInvalidOPDSData() {
-        XCTExpectFailure("Requires work in dependency to resolve the issue.")
         let content = "Invalid OPDS Data"
         XCTAssertThrowsError(
             try OPDSParser().parse(data: content.data(using: .utf8)!)


### PR DESCRIPTION
This enables the test case for invalid OPDS data input, which initially will fail.
Once libkiwix will return false, for invalid data input, this testcase should pass.
See: #874 and https://github.com/kiwix/libkiwix/issues/1099