### PR TITLE
Attempt to fix pop-over crash: remove extra modal style

### DIFF
--- a/Views/ActivityViewController.swift
+++ b/Views/ActivityViewController.swift
@@ -25,7 +25,6 @@ struct ActivityViewController: UIViewControllerRepresentable {
         context: UIViewControllerRepresentableContext<ActivityViewController>
     ) -> UIActivityViewController {
         let controller = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
-        controller.modalPresentationStyle = .pageSheet
         controller.completionWithItemsHandler = { (_, _, _, _) in
             self.dismissAction()
         }


### PR DESCRIPTION
Fixes: #857 

I could not fully re-create this crash locally, the only thing that I have found was related to this additional presentation style. I have tested it on both iPhone and iPad and turns out we do not need it, as the View is already presented via SwiftUI `.sheet`.
