### PR TITLE
Fix Crash with Single DB background context

### DIFF
--- a/App/App_iOS.swift
+++ b/App/App_iOS.swift
@@ -36,7 +36,7 @@ struct Kiwix: App {
         WindowGroup {
             RootView()
                 .ignoresSafeArea()
-                .environment(\.managedObjectContext, Database.viewContext)
+                .environment(\.managedObjectContext, Database.shared.viewContext)
                 .environmentObject(library)
                 .environmentObject(navigation)
                 .modifier(AlertHandler())
@@ -45,7 +45,7 @@ struct Kiwix: App {
                 .modifier(SaveContentHandler())
                 .onChange(of: scenePhase) { newValue in
                     guard newValue == .inactive else { return }
-                    try? Database.viewContext.save()
+                    try? Database.shared.viewContext.save()
                 }
                 .onOpenURL { url in
                     if url.isFileURL {

--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -149,9 +149,7 @@ struct RootView: View {
             case .categories:
                 ZimFilesCategories(dismiss: nil).modifier(LibraryZimFileDetailSidePanel())
             case .downloads:
-                ZimFilesDownloads(dismiss: nil)
-                    .environment(\.managedObjectContext, Database.shared.viewContext)
-                    .modifier(LibraryZimFileDetailSidePanel())
+                ZimFilesDownloads(dismiss: nil).modifier(LibraryZimFileDetailSidePanel())
             case .new:
                 ZimFilesNew(dismiss: nil).modifier(LibraryZimFileDetailSidePanel())
             default:

--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -39,7 +39,7 @@ struct Kiwix: App {
     var body: some Scene {
         WindowGroup {
             RootView()
-                .environment(\.managedObjectContext, Database.shared.container.viewContext)
+                .environment(\.managedObjectContext, Database.shared.viewContext)
                 .environmentObject(libraryRefreshViewModel)
         }.commands {
             SidebarCommands()
@@ -149,7 +149,9 @@ struct RootView: View {
             case .categories:
                 ZimFilesCategories(dismiss: nil).modifier(LibraryZimFileDetailSidePanel())
             case .downloads:
-                ZimFilesDownloads(dismiss: nil).modifier(LibraryZimFileDetailSidePanel())
+                ZimFilesDownloads(dismiss: nil)
+                    .environment(\.managedObjectContext, Database.shared.viewContext)
+                    .modifier(LibraryZimFileDetailSidePanel())
             case .new:
                 ZimFilesNew(dismiss: nil).modifier(LibraryZimFileDetailSidePanel())
             default:
@@ -214,10 +216,8 @@ struct RootView: View {
                 DownloadService.shared.restartHeartbeatIfNeeded()
             case let .custom(zimFileURL):
                 LibraryOperations.open(url: zimFileURL) {
-                    Task {
-                        await ZimMigration.forCustomApps()
-                        navigation.currentItem = .reading
-                    }
+                    ZimMigration.forCustomApps()
+                    navigation.currentItem = .reading
                 }
             }
         }

--- a/App/SidebarViewController.swift
+++ b/App/SidebarViewController.swift
@@ -40,7 +40,7 @@ class SidebarViewController: UICollectionViewController, NSFetchedResultsControl
     }()
     private let fetchedResultController = NSFetchedResultsController(
         fetchRequest: Tab.fetchRequest(sortDescriptors: [NSSortDescriptor(key: "created", ascending: false)]),
-        managedObjectContext: Database.viewContext,
+        managedObjectContext: Database.shared.viewContext,
         sectionNameKeyPath: nil,
         cacheName: nil
     )
@@ -187,7 +187,7 @@ class SidebarViewController: UICollectionViewController, NSFetchedResultsControl
     // MARK: - Collection View Configuration
 
     private func configureCell(cell: UICollectionViewListCell, indexPath: IndexPath, item: NavigationItem) {
-        if case let .tab(objectID) = item, let tab = try? Database.viewContext.existingObject(with: objectID) as? Tab {
+        if case let .tab(objectID) = item, let tab = try? Database.shared.viewContext.existingObject(with: objectID) as? Tab {
             var config = cell.defaultContentConfiguration()
             config.text = tab.title ?? "common.tab.menu.new_tab".localized
             if let zimFile = tab.zimFile, let category = Category(rawValue: zimFile.category) {

--- a/App/SidebarViewController.swift
+++ b/App/SidebarViewController.swift
@@ -187,7 +187,8 @@ class SidebarViewController: UICollectionViewController, NSFetchedResultsControl
     // MARK: - Collection View Configuration
 
     private func configureCell(cell: UICollectionViewListCell, indexPath: IndexPath, item: NavigationItem) {
-        if case let .tab(objectID) = item, let tab = try? Database.shared.viewContext.existingObject(with: objectID) as? Tab {
+        if case let .tab(objectID) = item,
+            let tab = try? Database.shared.viewContext.existingObject(with: objectID) as? Tab {
             var config = cell.defaultContentConfiguration()
             config.text = tab.title ?? "common.tab.menu.new_tab".localized
             if let zimFile = tab.zimFile, let category = Category(rawValue: zimFile.category) {

--- a/App/SplitViewController.swift
+++ b/App/SplitViewController.swift
@@ -111,7 +111,10 @@ final class SplitViewController: UISplitViewController {
             let controller = UIHostingController(rootView: ZimFilesCategories(dismiss: nil))
             setViewController(UINavigationController(rootViewController: controller), for: .secondary)
         case .downloads:
-            let controller = UIHostingController(rootView: ZimFilesDownloads(dismiss: nil))
+            let controller = UIHostingController(
+                rootView: ZimFilesDownloads(dismiss: nil)
+                    .environment(\.managedObjectContext, Database.shared.viewContext)
+            )
             setViewController(UINavigationController(rootViewController: controller), for: .secondary)
         case .new:
             let controller = UIHostingController(rootView: ZimFilesNew(dismiss: nil))

--- a/SwiftUI/Model/LibraryOperations.swift
+++ b/SwiftUI/Model/LibraryOperations.swift
@@ -43,7 +43,7 @@ struct LibraryOperations {
         }
 
         // upsert zim file in the database
-        Database.shared.container.performBackgroundTask { context in
+        Database.shared.performBackgroundTask { context in
             context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
             let predicate = NSPredicate(format: "fileID == %@", metadata.fileID as CVarArg)
             let fetchRequest = ZimFile.fetchRequest(predicate: predicate)
@@ -65,7 +65,7 @@ struct LibraryOperations {
     /// Reopen zim files from url bookmark data.
     static func reopen(onComplete: (() -> Void)?) {
         var successCount = 0
-        let context = Database.shared.container.viewContext
+        let context = Database.shared.viewContext
         let request = ZimFile.fetchRequest(predicate: ZimFile.Predicate.isDownloaded)
 
         guard let zimFiles = try? context.fetch(request) else {
@@ -149,7 +149,7 @@ struct LibraryOperations {
     /// - Parameter zimFile: the zim file to unlink
     static func unlink(zimFileID: UUID) {
         ZimFileService.shared.close(fileID: zimFileID)
-        Database.shared.container.performBackgroundTask { context in
+        Database.shared.performBackgroundTask { context in
             context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
             guard let zimFile = try? ZimFile.fetchRequest(fileID: zimFileID).execute().first else { return }
             zimFile.bookmarks.forEach { context.delete($0) }

--- a/Tests/CategoryFetchingTests.swift
+++ b/Tests/CategoryFetchingTests.swift
@@ -27,7 +27,7 @@ final class CategoryFetchingTests: XCTestCase {
 
     func testFilteredOutByLanguage() throws {
         // insert a zimFile
-        let context = Database.viewContext
+        let context = Database.shared.viewContext
         let zimFile = ZimFile(context: context)
         let metadata = ZimFileMetaData.mock(languageCodes: "eng",
                                             category: Category.other.rawValue)
@@ -45,7 +45,7 @@ final class CategoryFetchingTests: XCTestCase {
 
     func testCanBeFoundByLanguage() throws {
         // insert a zimFile
-        let context = Database.viewContext
+        let context = Database.shared.viewContext
         let zimFile = ZimFile(context: context)
         let metadata = ZimFileMetaData.mock(languageCodes: "eng",
                                             category: Category.other.rawValue)
@@ -63,7 +63,7 @@ final class CategoryFetchingTests: XCTestCase {
 
     func testCanBeFoundByMultipleUserLanguages() throws {
         // insert a zimFile
-        let context = Database.viewContext
+        let context = Database.shared.viewContext
         let zimFile = ZimFile(context: context)
         let metadata = ZimFileMetaData.mock(languageCodes: "fra",
                                             category: Category.other.rawValue)
@@ -81,7 +81,7 @@ final class CategoryFetchingTests: XCTestCase {
 
     func testCanBeFoundHavingMultiLanguagesWithASingleUserLanguage() throws {
         // insert a zimFile
-        let context = Database.viewContext
+        let context = Database.shared.viewContext
         let zimFile = ZimFile(context: context)
         let metadata = ZimFileMetaData.mock(languageCodes: "eng,fra,deu,nld,spa,ita,por,pol,ara,vie,kor",
                                             category: Category.other.rawValue)
@@ -99,7 +99,7 @@ final class CategoryFetchingTests: XCTestCase {
 
     func testCanBeFoundHavingMultiLanguageMatches() throws {
         // insert a zimFile
-        let context = Database.viewContext
+        let context = Database.shared.viewContext
         let zimFile = ZimFile(context: context)
         let metadata = ZimFileMetaData.mock(languageCodes: "eng,fra,deu,nld,spa,ita,por,pol,ara,vie,kor",
                                             category: Category.other.rawValue)
@@ -117,7 +117,7 @@ final class CategoryFetchingTests: XCTestCase {
 
     func testFilteredOutByMultiToMultiLanguageMissMatch() throws {
         // insert a zimFile
-        let context = Database.viewContext
+        let context = Database.shared.viewContext
         let zimFile = ZimFile(context: context)
         let metadata = ZimFileMetaData.mock(languageCodes: "eng,fra,deu,nld,spa,ita",
                                             category: Category.other.rawValue)
@@ -134,7 +134,7 @@ final class CategoryFetchingTests: XCTestCase {
     }
 
     private func resetDB() throws {
-        _ = try Database.viewContext.execute(
+        _ = try Database.shared.viewContext.execute(
             NSBatchDeleteRequest(
                 fetchRequest: NSFetchRequest(entityName: ZimFile.entity().name!)
             )

--- a/Tests/LibraryRefreshViewModelTest.swift
+++ b/Tests/LibraryRefreshViewModelTest.swift
@@ -171,7 +171,7 @@ final class LibraryRefreshViewModelTest: XCTestCase {
         XCTAssertNil(viewModel.error)
 
         // check one zim file is in the database
-        let context = Database.shared.container.viewContext
+        let context = Database.shared.viewContext
         let zimFiles = try context.fetch(ZimFile.fetchRequest())
         XCTAssertEqual(zimFiles.count, 1)
         XCTAssertEqual(zimFiles[0].id, zimFileID)
@@ -215,7 +215,7 @@ final class LibraryRefreshViewModelTest: XCTestCase {
         // refresh library for the first time, which should create one zim file
         let viewModel = LibraryViewModel(urlSession: urlSession)
         await viewModel.start(isUserInitiated: true)
-        let context = Database.shared.container.viewContext
+        let context = Database.shared.viewContext
         let zimFile1 = try XCTUnwrap(try context.fetch(ZimFile.fetchRequest()).first)
 
         // refresh library for the second time, which should replace the old zim file with a new one

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -104,7 +104,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
         // Bookmark fetching:
         bookmarkFetchedResultsController = NSFetchedResultsController(
             fetchRequest: Bookmark.fetchRequest(), // initially empty
-            managedObjectContext: Database.viewContext,
+            managedObjectContext: Database.shared.viewContext,
             sectionNameKeyPath: nil,
             cacheName: nil
         )
@@ -183,7 +183,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
     private func didUpdate(title: String, url: URL) {
         let zimFile: ZimFile? = {
             guard let zimFileID = UUID(uuidString: url.host ?? "") else { return nil }
-            return try? Database.viewContext.fetch(ZimFile.fetchRequest(fileID: zimFileID)).first
+            return try? Database.shared.viewContext.fetch(ZimFile.fetchRequest(fileID: zimFileID)).first
         }()
 
         metaData = ZimFileService.shared.getContentMetaData(url: url)
@@ -204,14 +204,14 @@ final class BrowserViewModel: NSObject, ObservableObject,
         tabID = currentTabID
 
         // update tab data
-        if let tab = try? Database.viewContext.existingObject(with: currentTabID) as? Tab {
+        if let tab = try? Database.shared.viewContext.existingObject(with: currentTabID) as? Tab {
             tab.title = articleTitle
             tab.zimFile = zimFile
         }
     }
 
     func updateLastOpened() {
-        guard let tabID, let tab = try? Database.viewContext.existingObject(with: tabID) as? Tab else { return }
+        guard let tabID, let tab = try? Database.shared.viewContext.existingObject(with: tabID) as? Tab else { return }
         tab.lastOpened = Date()
     }
 
@@ -221,11 +221,11 @@ final class BrowserViewModel: NSObject, ObservableObject,
 
     func persistState() {
         guard let tabID,
-              let tab = try? Database.viewContext.existingObject(with: tabID) as? Tab else {
+              let tab = try? Database.shared.viewContext.existingObject(with: tabID) as? Tab else {
             return
         }
         tab.interactionState = webView.interactionState as? Data
-        try? Database.viewContext.save()
+        try? Database.shared.viewContext.save()
     }
 
     // MARK: - Content Loading
@@ -251,7 +251,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
     }
 
     private func restoreBy(tabID: NSManagedObjectID) {
-        if let tab = try? Database.viewContext.existingObject(with: tabID) as? Tab {
+        if let tab = try? Database.shared.viewContext.existingObject(with: tabID) as? Tab {
             webView.interactionState = tab.interactionState
             Task {
                 await MainActor.run {
@@ -501,7 +501,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
 
                 // bookmark
                 let bookmarkAction: UIAction = {
-                    let context = Database.viewContext
+                    let context = Database.shared.viewContext
                     let predicate = NSPredicate(format: "articleURL == %@", url as CVarArg)
                     let request = Bookmark.fetchRequest(predicate: predicate)
 
@@ -596,7 +596,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
 
     private func createNewTabID() -> NSManagedObjectID {
         if let tabID { return tabID }
-        let context = Database.viewContext
+        let context = Database.shared.viewContext
         let tab = Tab(context: context)
         tab.created = Date()
         tab.lastOpened = Date()
@@ -615,7 +615,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
     func createBookmark(url: URL? = nil) {
         guard let url = url ?? webView.url else { return }
         let title = webView.title
-        Database.performBackgroundTask { context in
+        Database.shared.performBackgroundTask { context in
             let bookmark = Bookmark(context: context)
             bookmark.articleURL = url
             bookmark.created = Date()
@@ -631,7 +631,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
 
     func deleteBookmark(url: URL? = nil) {
         guard let url = url ?? webView.url else { return }
-        Database.performBackgroundTask { context in
+        Database.shared.performBackgroundTask { context in
             let request = Bookmark.fetchRequest(predicate: NSPredicate(format: "articleURL == %@", url as CVarArg))
             guard let bookmark = try? context.fetch(request).first else { return }
             context.delete(bookmark)

--- a/ViewModel/SearchViewModel.swift
+++ b/ViewModel/SearchViewModel.swift
@@ -34,7 +34,7 @@ class SearchViewModel: NSObject, ObservableObject, NSFetchedResultsControllerDel
         let predicate = NSPredicate(format: "includedInSearch == true AND fileURLBookmark != nil")
         fetchedResultsController = NSFetchedResultsController(
             fetchRequest: ZimFile.fetchRequest(predicate: predicate),
-            managedObjectContext: Database.shared.container.viewContext,
+            managedObjectContext: Database.shared.viewContext,
             sectionNameKeyPath: nil,
             cacheName: nil
         )

--- a/Views/Library/Library.swift
+++ b/Views/Library/Library.swift
@@ -57,6 +57,7 @@ struct Library: View {
                         .navigationTitle(NavigationItem.categories.name)
                     case .downloads:
                         ZimFilesDownloads(dismiss: dismiss)
+                            .environment(\.managedObjectContext, Database.shared.viewContext)
                     case .new:
                         ZimFilesNew(dismiss: dismiss)
                     }
@@ -79,7 +80,7 @@ struct Library_Previews: PreviewProvider {
         NavigationStack {
             Library(dismiss: nil)
                 .environmentObject(LibraryViewModel())
-                .environment(\.managedObjectContext, Database.viewContext)
+                .environment(\.managedObjectContext, Database.shared.viewContext)
         }
     }
 }

--- a/Views/Library/ZimFileDetail.swift
+++ b/Views/Library/ZimFileDetail.swift
@@ -179,7 +179,10 @@ struct ZimFileDetail: View {
                     }
                 }()),
                 primaryButton: .default(Text("zim_file.action.download.button.anyway".localized)) {
-                    DownloadService.shared.start(zimFileID: zimFile.id, allowsCellularAccess: false)
+                    DownloadService.shared.start(
+                        zimFileID: zimFile.id,
+                        allowsCellularAccess: false
+                    )
                 },
                 secondaryButton: .cancel()
             )

--- a/Views/Library/ZimFilesNew.swift
+++ b/Views/Library/ZimFilesNew.swift
@@ -115,7 +115,7 @@ struct ZimFilesNew_Previews: PreviewProvider {
         NavigationStack {
             ZimFilesNew(dismiss: nil)
                 .environmentObject(LibraryViewModel())
-                .environment(\.managedObjectContext, Database.viewContext)
+                .environment(\.managedObjectContext, Database.shared.viewContext)
         }
     }
 }

--- a/Views/Settings/LanguageSelector.swift
+++ b/Views/Settings/LanguageSelector.swift
@@ -165,8 +165,7 @@ class Languages {
         fetchRequest.resultType = .dictionaryResultType
 
         let languages: [Language] = await withCheckedContinuation { continuation in
-            let context = Database.shared.container.newBackgroundContext()
-            context.perform {
+            Database.shared.performBackgroundTask { context in
                 guard let results = try? context.fetch(fetchRequest) else {
                     continuation.resume(returning: [])
                     return


### PR DESCRIPTION
Fixes: #877

We had multiple background contexts from which the DB queries were operating, without much of synchronisation, but at the end they were forced to merge there changes into a single place.
Additionally to that, we had a token mechanism to synchronise these contexts, which was crashing from time to time.

Solution:
- Use Apple's built in merge context solution, which is easier in our scenario (the token based approach is more appropriate for App Extensions such as Lock Screen widgets and so on, which we do not have).
- Make sure we use a single background context the queries of which are also queued up properly, so there's less of a chance for conflicts.

Tested on macOS, iPad and iPhone. Both the download and the category fetching / parsing, and other DB related actions, such as tab management.