### PR TITLE
Make sure only utf8 compatible data can be passed into OPDS Parsing

### DIFF
--- a/Model/OPDSParser/OPDSParser.mm
+++ b/Model/OPDSParser/OPDSParser.mm
@@ -42,6 +42,9 @@
 - (BOOL)parseData:(nonnull NSData *)data {
     try {
         NSString *content = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        if (content == nil) {
+            return false;
+        }
         std::shared_ptr<kiwix::Manager> manager = std::make_shared<kiwix::Manager>(self.library);
         return manager->readOpds([content cStringUsingEncoding:NSUTF8StringEncoding],
                                  [@"https://library.kiwix.org" cStringUsingEncoding:NSUTF8StringEncoding]);

--- a/Model/OPDSParser/OPDSParser.swift
+++ b/Model/OPDSParser/OPDSParser.swift
@@ -25,8 +25,7 @@ extension OPDSParser: Parser {
     }
 
     func parse(data: Data) throws {
-        guard String(data: data, encoding: .utf8) != nil,
-              self.__parseData(data) else {
+        if !self.__parseData(data) {
             throw LibraryRefreshError.parse
         }
     }

--- a/Model/OPDSParser/OPDSParser.swift
+++ b/Model/OPDSParser/OPDSParser.swift
@@ -25,7 +25,8 @@ extension OPDSParser: Parser {
     }
 
     func parse(data: Data) throws {
-        if !self.__parseData(data) {
+        guard String(data: data, encoding: .utf8) != nil,
+              self.__parseData(data) else {
             throw LibraryRefreshError.parse
         }
     }

--- a/Tests/OPDSParserTests.swift
+++ b/Tests/OPDSParserTests.swift
@@ -28,7 +28,8 @@ final class OPDSParserTests: XCTestCase {
 
     func testNonCompatibleDataWithUT8() throws {
         let content = "any data"
-        try String.Encoding.nonUTF8CompatibleCases.forEach { encoding in
+        let incompatibleEncodings: [String.Encoding] = [.unicode, .utf16, .utf32]
+        try incompatibleEncodings.forEach { encoding in
             XCTAssertThrowsError(
                 try OPDSParser().parse(data: content.data(using: encoding)!),
                 "parsing with enconding \(encoding.description) should fail"
@@ -111,16 +112,4 @@ final class OPDSParserTests: XCTestCase {
         )
         XCTAssertEqual(metadata.flavor, "maxi")
     }
-}
-
-private extension String.Encoding {
-    static var nonUTF8CompatibleCases: [String.Encoding] {
-        [
-         .unicode,
-         .utf16,
-         .utf32
-        ]
-    }
-    
-
 }

--- a/Tests/OPDSParserTests.swift
+++ b/Tests/OPDSParserTests.swift
@@ -26,6 +26,16 @@ final class OPDSParserTests: XCTestCase {
         )
     }
 
+    func testNonCompatibleDataWithUT8() throws {
+        let content = "any data"
+        try String.Encoding.nonUTF8CompatibleCases.forEach { encoding in
+            XCTAssertThrowsError(
+                try OPDSParser().parse(data: content.data(using: encoding)!),
+                "parsing with enconding \(encoding.description) should fail"
+            )
+        }
+    }
+
     /// Test OPDSParser.getMetaData returns nil when no metadata available with the given ID.
     func testMetadataNotFound() {
         let zimFileID = UUID(uuidString: "1ec90eab-5724-492b-9529-893959520de4")!
@@ -101,4 +111,16 @@ final class OPDSParserTests: XCTestCase {
         )
         XCTAssertEqual(metadata.flavor, "maxi")
     }
+}
+
+private extension String.Encoding {
+    static var nonUTF8CompatibleCases: [String.Encoding] {
+        [
+         .unicode,
+         .utf16,
+         .utf32
+        ]
+    }
+    
+
 }


### PR DESCRIPTION
Fixes: #874 

It turned out that if the data passed in is UTF8 compatible we won't have a crash, no matter how invalid the content of the data is (eg. not an xml format).

Whereas it was possible to crash the app with non uff-8 compatible input, like so:
<img width="1081" alt="Screenshot 2024-07-27 at 12 53 46" src="https://github.com/user-attachments/assets/56a98001-0c0b-46a9-b4f5-a7fd8019765f">

Luckily we can handle this check on the swift / reader side.

Related unit tests were added, making sure we throw an error before the data with invalid encodings goes any deeper.




