### PR TITLE
Fix search result list display of Japanese wikipedia

### DIFF
--- a/SwiftUI/Model/SearchOperation/SearchOperation.swift
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.swift
@@ -39,7 +39,8 @@ extension SearchOperation {
                           let data = html.data(using: .utf8) else { return }
                     result.snippet = try? NSAttributedString(
                         data: data,
-                        options: [.documentType: NSAttributedString.DocumentType.html, .characterEncoding: String.Encoding.utf8.rawValue],
+                        options: [.documentType: NSAttributedString.DocumentType.html,
+                                  .characterEncoding: String.Encoding.utf8.rawValue],
                         documentAttributes: nil
                     )
                 case .disabled:

--- a/SwiftUI/Model/SearchOperation/SearchOperation.swift
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.swift
@@ -39,7 +39,7 @@ extension SearchOperation {
                           let data = html.data(using: .utf8) else { return }
                     result.snippet = try? NSAttributedString(
                         data: data,
-                        options: [.documentType: NSAttributedString.DocumentType.html],
+                        options: [.documentType: NSAttributedString.DocumentType.html, .characterEncoding: String.Encoding.utf8.rawValue],
                         documentAttributes: nil
                     )
                 case .disabled:


### PR DESCRIPTION
When searching Japanese Wikipedia, a summary of each search result is drawn in broken characters as shown in the image below.

![スクリーンショット 2024-07-29 8 51 00](https://github.com/user-attachments/assets/c947aa6e-fcb5-4472-ab06-78241cb59d37)

This is probably due to the fact that encoding is not specified when converting HTML strings to `NSAttributedString`.
When this is corrected, the summary is correctly displayed as follows.

![スクリーンショット 2024-07-29 15 03 18](https://github.com/user-attachments/assets/95770d82-64b3-4af5-ac70-c65e69abc345)
