### PR TITLE
Blocking any JS files, that contains video or ogv in the name, to fix video issues

### DIFF
--- a/Model/Utilities/WebKitHandler.swift
+++ b/Model/Utilities/WebKitHandler.swift
@@ -81,6 +81,14 @@ final class KiwixURLSchemeHandler: NSObject, WKURLSchemeHandler {
             stopFor(urlSchemeTask.hash)
             return
         }
+        // blocking any video or ogv javascript files to be loaded
+        let fileName = url.lastPathComponent
+        if fileName.hasSuffix(".js"),
+           (fileName.contains("video") || fileName.contains("ogv")) {
+            urlSchemeTask.didFailWithError(URLError(.resourceUnavailable))
+            stopFor(urlSchemeTask.hash)
+        }
+
         guard let metaData = await contentMetaData(for: url) else {
             sendHTTP404Response(urlSchemeTask, url: url)
             return


### PR DESCRIPTION
Fixes: #889 

It's a bit hack... since the content cannot be changed, and it works better without those JS files, it is possible solution to our problem.