### PR TITLE
WebKitHandler concurrency fix

### DIFF
--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -397,10 +397,12 @@ final class BrowserViewModel: NSObject, ObservableObject,
         withError error: Error
     ) {
         let error = error as NSError
-        webView.stopLoading()
-        (webView.configuration
-            .urlSchemeHandler(forURLScheme: KiwixURLSchemeHandler.KiwixScheme) as? KiwixURLSchemeHandler)?
-            .didFailProvisionalNavigation()
+        Task { @MainActor in
+            webView.stopLoading()
+            (webView.configuration
+                .urlSchemeHandler(forURLScheme: KiwixURLSchemeHandler.KiwixScheme) as? KiwixURLSchemeHandler)?
+                .didFailProvisionalNavigation()
+        }
         guard error.code != NSURLErrorCancelled else { return }
         guard canShowMimeType else {
             guard let kiwixURL = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL else {


### PR DESCRIPTION
Fixes: #895 

It turned out that it was a concurrency issue after all.
It was possible to execute a next step while we were receiving a "stop signal" from the Apple framework, due to the context switch to another thread, which also takes a fraction of time.

By adding `@MainActor` to the framework handle functions, it is now working as expected.
The additional thread safety could be simplified this way as well.

I leave it as a separate fix, for future reference (as it wasn't obvious at all), but I did tested this fix on both the main branch and on the range-request branch as well, and it works great.


