### PR TITLE
Fix incorrect language selector list in library settings

### DIFF
--- a/Views/Settings/LanguageSelector.swift
+++ b/Views/Settings/LanguageSelector.swift
@@ -189,7 +189,7 @@ class Languages {
                 languagesMap[code] = (languagesMap[code] ?? 0) + 1
             }
         }
-        let languagesList : [Language] = languagesMap.enumerated().compactMap {
+        let languagesList: [Language] = languagesMap.enumerated().compactMap {
             let elem = $0.element
             return Language(code: elem.key, count: elem.value)
         }

--- a/Views/Settings/LanguageSelector.swift
+++ b/Views/Settings/LanguageSelector.swift
@@ -182,11 +182,10 @@ class Languages {
         let languagesMulti = languages.filter { $0.0.contains(",") }
         let languagesSingle = languages.filter { !$0.0.contains(",") }
         var languagesMap = Dictionary(uniqueKeysWithValues: languagesSingle)
-        for lang in languagesMulti {
-            let codes = lang.0
+        for (codes, count) in languagesMulti {
             for codeSubstring in Set(codes.split(separator: ",")) {
                 let code = String(codeSubstring)
-                languagesMap[code] = (languagesMap[code] ?? 0) + 1
+                languagesMap[code] = (languagesMap[code] ?? 0) + count
             }
         }
         let languagesList: [Language] = languagesMap.enumerated().compactMap {


### PR DESCRIPTION
The language list in the library settings panel seems to have the following problems, as shown in the following figure:

- Some language names are displayed in internal strings (e.g. `eng,por,spa,...`) ,
- ZIM files count is not correct.

![スクリーンショット 2024-08-03 21 24 43](https://github.com/user-attachments/assets/2c457eb7-7b95-423d-bdb6-b53022a435ca)

This seems to be due to the fact that if multiple languages are set in the language attribute of the ZIM file, they are not handled correctly.

This PR attempts to correct that.