### PR TITLE
Change to release version 3.5.0

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -99,7 +99,7 @@ targets:
         com.apple.security.files.downloads.read-write: true
     settings:
       base:
-        MARKETING_VERSION: "3.4.1"
+        MARKETING_VERSION: "3.5.0"
         PRODUCT_BUNDLE_IDENTIFIER: self.Kiwix
         INFOPLIST_KEY_CFBundleDisplayName: Kiwix
         INFOPLIST_FILE: Support/Info.plist


### PR DESCRIPTION
Before we do the release we need to align the version number to our updated milestone.
We can merge this after the weekly builds run, as the App Store version needs to be changed as well.