### PR TITLE
Fix crash: opening ZIM directly after download crashes the app on iPad

### DIFF
--- a/Model/DownloadService.swift
+++ b/Model/DownloadService.swift
@@ -221,8 +221,8 @@ final class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegat
         Task { @MainActor [weak progress] in
             progress?.resetFor(uuid: zimFileID)
         }
-        let context = Database.shared.viewContext
-        context.perform {
+        Database.shared.performBackgroundTask { context in
+            context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
             do {
                 let request = DownloadTask.fetchRequest(fileID: zimFileID)
                 guard let downloadTask = try context.fetch(request).first else { return }

--- a/Model/DownloadService.swift
+++ b/Model/DownloadService.swift
@@ -27,6 +27,10 @@ struct DownloadState: Codable {
     let total: Int64
     let resumeData: Data?
 
+    static func empty() -> DownloadState {
+        .init(downloaded: 0, total: 1, resumeData: nil)
+    }
+
     init(downloaded: Int64, total: Int64, resumeData: Data?) {
         guard total >= downloaded, total > 0 else {
             assertionFailure("invalid download progress values: downloaded \(downloaded) total: \(total)")

--- a/Model/DownloadService.swift
+++ b/Model/DownloadService.swift
@@ -221,8 +221,8 @@ final class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegat
         Task { @MainActor [weak progress] in
             progress?.resetFor(uuid: zimFileID)
         }
-        Database.shared.performBackgroundTask { context in
-            context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+        let context = Database.shared.viewContext
+        context.perform {
             do {
                 let request = DownloadTask.fetchRequest(fileID: zimFileID)
                 guard let downloadTask = try context.fetch(request).first else { return }

--- a/Views/BuildingBlocks/DownloadTaskCell.swift
+++ b/Views/BuildingBlocks/DownloadTaskCell.swift
@@ -23,9 +23,9 @@ struct DownloadTaskCell: View {
     @State private var isHovering: Bool = false
     @State private var downloadState = DownloadState(downloaded: 0, total: 1, resumeData: nil)
 
-    let downloadTask: DownloadTask
-    init(_ downloadTask: DownloadTask) {
-        self.downloadTask = downloadTask
+    let downloadZimFile: ZimFile
+    init(_ downloadZimFile: ZimFile) {
+        self.downloadZimFile = downloadZimFile
     }
 
     var body: some View {
@@ -38,21 +38,17 @@ struct DownloadTaskCell: View {
             return prog
         }()
         VStack(spacing: 8) {
-            if let zimFile = downloadTask.zimFile {
-                HStack {
-                    Text(zimFile.name).fontWeight(.semibold).foregroundColor(.primary).lineLimit(1)
-                    Spacer()
-                    Favicon(
-                        category: Category(rawValue: zimFile.category) ?? .other,
-                        imageData: zimFile.faviconData,
-                        imageURL: zimFile.faviconURL
-                    ).frame(height: 20)
-                }
-            } else {
-                Text(downloadTask.fileID.uuidString)
+            HStack {
+                Text(downloadZimFile.name).fontWeight(.semibold).foregroundColor(.primary).lineLimit(1)
+                Spacer()
+                Favicon(
+                    category: Category(rawValue: downloadZimFile.category) ?? .other,
+                    imageData: downloadZimFile.faviconData,
+                    imageURL: downloadZimFile.faviconURL
+                ).frame(height: 20)
             }
             VStack(alignment: .leading, spacing: 4) {
-                if downloadTask.error != nil {
+                if downloadZimFile.downloadTask?.error != nil {
                     Text("download_task_cell.status.failed".localized)
                 } else if downloadState.resumeData == nil {
                     Text("download_task_cell.status.downloading".localized)
@@ -70,7 +66,7 @@ struct DownloadTaskCell: View {
         .modifier(CellBackground(isHovering: isHovering))
         .onHover { self.isHovering = $0 }
         .onReceive(DownloadService.shared.progress.publisher) { states in
-            if let state = states[downloadTask.fileID] {
+            if let state = states[downloadZimFile.fileID] {
                 self.downloadState = state
             }
         }
@@ -91,6 +87,7 @@ struct DownloadTaskCell_Previews: PreviewProvider {
         zimFile.name = "Wikipedia"
         zimFile.persistentID = ""
         zimFile.size = 1000000000
+        zimFile.downloadTask = downloadTask
         return zimFile
     }()
     static let downloadTask: DownloadTask = {
@@ -100,12 +97,12 @@ struct DownloadTaskCell_Previews: PreviewProvider {
     }()
 
     static var previews: some View {
-        DownloadTaskCell(DownloadTaskCell_Previews.downloadTask)
+        DownloadTaskCell(zimFile)
             .preferredColorScheme(.light)
             .padding()
             .frame(width: 300, height: 125)
             .previewLayout(.sizeThatFits)
-        DownloadTaskCell(DownloadTaskCell_Previews.downloadTask)
+        DownloadTaskCell(zimFile)
             .preferredColorScheme(.dark)
             .padding()
             .frame(width: 300, height: 125)

--- a/Views/Library/ZimFileDetail.swift
+++ b/Views/Library/ZimFileDetail.swift
@@ -90,7 +90,7 @@ struct ZimFileDetail: View {
 
     @ViewBuilder
     var actions: some View {
-        if let _ = zimFile.downloadTask {  // zim file is being downloaded
+        if zimFile.downloadTask != nil {  // zim file is being downloaded
             DownloadTaskDetail(downloadZimFile: zimFile)
         } else if zimFile.isMissing {  // zim file was opened, but is now missing
             Action(title: "zim_file.action.locate.title".localized) { isPresentingFileLocator = true }

--- a/Views/Library/ZimFileDetail.swift
+++ b/Views/Library/ZimFileDetail.swift
@@ -90,8 +90,8 @@ struct ZimFileDetail: View {
 
     @ViewBuilder
     var actions: some View {
-        if let downloadTask = zimFile.downloadTask {  // zim file is being downloaded
-            DownloadTaskDetail(downloadTask: downloadTask)
+        if let _ = zimFile.downloadTask {  // zim file is being downloaded
+            DownloadTaskDetail(downloadZimFile: zimFile)
         } else if zimFile.isMissing {  // zim file was opened, but is now missing
             Action(title: "zim_file.action.locate.title".localized) { isPresentingFileLocator = true }
             unlinkAction
@@ -254,46 +254,45 @@ private struct FileLocator: ViewModifier {
 }
 
 private struct DownloadTaskDetail: View {
-    @ObservedObject var downloadTask: DownloadTask
+    @ObservedObject var downloadZimFile: ZimFile
     @EnvironmentObject var viewModel: LibraryViewModel
     @State private var downloadState = DownloadState.empty()
-    private var downloadFileID: UUID? {
-        viewModel.selectedZimFile?.fileID
-    }
 
     var body: some View {
         Group {
             Action(title: "zim_file.download_task.action.title.cancel".localized, isDestructive: true) {
-                DownloadService.shared.cancel(zimFileID: downloadTask.fileID)
+                DownloadService.shared.cancel(zimFileID: downloadZimFile.fileID)
                 viewModel.selectedZimFile = nil
             }
-            if let error = downloadTask.error {
+            if let error = downloadZimFile.downloadTask?.error {
                 if downloadState.resumeData != nil {
                     Action(title: "zim_file.download_task.action.try_recover".localized) {
-                        DownloadService.shared.resume(zimFileID: downloadTask.fileID)
+                        DownloadService.shared.resume(zimFileID: downloadZimFile.fileID)
                     }
                 }
                 Attribute(title: "zim_file.download_task.action.failed".localized, detail: detail)
                 Text(error)
             } else if downloadState.resumeData == nil {
                 Action(title: "zim_file.download_task.action.pause".localized) {
-                    DownloadService.shared.pause(zimFileID: downloadTask.fileID)
+                    DownloadService.shared.pause(zimFileID: downloadZimFile.fileID)
                 }
                 Attribute(title: "zim_file.download_task.action.downloading".localized, detail: detail)
             } else {
                 Action(title: "zim_file.download_task.action.resume".localized) {
-                    DownloadService.shared.resume(zimFileID: downloadTask.fileID)
+                    DownloadService.shared.resume(zimFileID: downloadZimFile.fileID)
                 }
                 Attribute(title: "zim_file.download_task.action.paused".localized, detail: detail)
             }
-        }.onReceive(DownloadService.shared.progress.publisher) { [self] (states: [UUID: DownloadState]) in
-            if let downloadFileID,
-               let state = states[downloadFileID] {
-                downloadState = state
-            } else {
-                downloadState = .empty()
-            }
-        }
+        }.onReceive(
+            DownloadService.shared.progress.publisher
+                .compactMap { [self] (states: [UUID: DownloadState]) -> DownloadState? in
+                    return states[downloadZimFile.fileID]
+                }, perform: { [self] (state: DownloadState?) in
+                    if let state {
+                        self.downloadState = state
+                    }
+                }
+        )
     }
 
     var detail: String {

--- a/Views/Library/ZimFilesDownloads.swift
+++ b/Views/Library/ZimFilesDownloads.swift
@@ -37,7 +37,7 @@ struct ZimFilesDownloads: View {
         ) {
             ForEach(downloadTasks) { downloadTask in
                 if let zimFile = downloadTask.zimFile {
-                    DownloadTaskCell(downloadTask).modifier(LibraryZimFileContext(zimFile: zimFile, dismiss: dismiss))
+                    DownloadTaskCell(zimFile).modifier(LibraryZimFileContext(zimFile: zimFile, dismiss: dismiss))
                 }
             }
         }


### PR DESCRIPTION
Fix: #920

After my investigation it turned out that the real problem lied somewhere deeper.
My former fix in 7e706f32ad19fb353fb28209814c1bd07db7be94 did solved only part of the issue, and postponed the problem to the point where the download is finished.

## Background:
We select a ZIMFile, for that we create a DownloadTask which keeps track of our progress, and can resume after app restart. So far so good.

The DownloadDetails view was relying on the DownloadTask itself, since that had a back reference to the ZIMFile, it could display all necessary details.

The problem is, that as it turns out SwiftUI has a bug, that if you delete the underlying managed object in our case the DownloadTask, which is deleted after the download completes, well... SwiftUI will just hold on to the old reference of that object, and will crash.
See the related problems reported by others here: 
https://stackoverflow.com/questions/59123439/swiftui-holding-reference-to-deleted-core-data-object-causing-crash

## The solution
Since we start the whole process from the ZIMFile, which also has an optional reference to the DownloadTask, we can base our views on the ZIMFile instead, which might or might not have a DownloadTask. Since we operate on the optional value of DownloadTask, it won't crash.

### TLDR:
We replace all of the ``downloadTask`` strong references in those views with ``downloadZimFile.downloadTask?`` and it stops crashing.
