### PR TITLE
Fix iPhone video starting with a black screen on iOS 17 iPhone

### DIFF
--- a/Support/injection.js
+++ b/Support/injection.js
@@ -89,19 +89,19 @@ function disableVideoContextMenu() {
 
 function removeVideoPosters() {
 
-    function removePosterAttributes(element) {
+    function fixVideoAttributes(element) {
         element.querySelectorAll("video").forEach((video) => {
             const attributes = video.attributes
             if(attributes.getNamedItem('poster')) {
-                attributes.removeNamedItem("poster");
+                attributes.removeNamedItem('poster');
             }
         });
     }
 
-    // remove from the current document
-    removePosterAttributes(document);
+    // fix in the currently loaded DOM
+    fixVideoAttributes(document);
 
-    // observe the dom, if video content is added, fix that as well
+    // observe the DOM, if video content is added, fix that as well
     var observeDOM = (function() {
         var MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
 
@@ -126,7 +126,7 @@ function removeVideoPosters() {
             if (mutation.type === 'childList' & mutation.addedNodes.length) {
                 for (const addedNode of mutation.addedNodes) {
                     if(addedNode.querySelectorAll) {
-                        removePosterAttributes(addedNode);
+                        fixVideoAttributes(addedNode);
                     }
                 }
             }

--- a/Support/injection.js
+++ b/Support/injection.js
@@ -87,10 +87,7 @@ function disableVideoContextMenu() {
     });
 }
 
-// for iOS 17 we need to remove the poster
-// to solve the issue with the video play starting
-// in a full black screen
-function removeVideoPosterOniOS17() {
+function removeVideoPosters() {
     document.querySelectorAll("video").forEach((video) => {
         video.attributes.removeNamedItem("poster");
     });

--- a/Support/injection.js
+++ b/Support/injection.js
@@ -87,7 +87,7 @@ function disableVideoContextMenu() {
     });
 }
 
-function removeVideoPosters() {
+function fixVideoElements() {
 
     function fixVideoAttributes(element) {
         element.querySelectorAll("video").forEach((video) => {

--- a/Support/injection.js
+++ b/Support/injection.js
@@ -88,7 +88,48 @@ function disableVideoContextMenu() {
 }
 
 function removeVideoPosters() {
-    document.querySelectorAll("video").forEach((video) => {
-        video.attributes.removeNamedItem("poster");
+
+    function removePosterAttributes(element) {
+        element.querySelectorAll("video").forEach((video) => {
+            const attributes = video.attributes
+            if(attributes.getNamedItem('poster')) {
+                attributes.removeNamedItem("poster");
+            }
+        });
+    }
+
+    // remove from the current document
+    removePosterAttributes(document);
+
+    // observe the dom, if video content is added, fix that as well
+    var observeDOM = (function() {
+        var MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
+
+        return function(obj, callback) {
+            if (!obj || obj.nodeType !== 1) {
+                return;
+            }
+
+            if (MutationObserver) {
+                // define a new observer
+                var mutationObserver = new MutationObserver(callback);
+                // have the observer observe for changes in children
+                mutationObserver.observe(obj, {attributes: false, childList: true, subtree: true});
+                return mutationObserver;
+            }
+        }
+    })();
+
+    // Observe the body DOM element:
+    observeDOM(document.querySelector('body'), function(mutationList) {
+        for (const mutation of mutationList) {
+            if (mutation.type === 'childList' & mutation.addedNodes.length) {
+                for (const addedNode of mutation.addedNodes) {
+                    if(addedNode.querySelectorAll) {
+                        removePosterAttributes(addedNode);
+                    }
+                }
+            }
+        }
     });
 }

--- a/Support/injection.js
+++ b/Support/injection.js
@@ -86,3 +86,12 @@ function disableVideoContextMenu() {
         video.addEventListener("contextmenu", function(e) { e.preventDefault(); }, false);
     });
 }
+
+// for iOS 17 we need to remove the poster
+// to solve the issue with the video play starting
+// in a full black screen
+function removeVideoPosterOniOS17() {
+    document.querySelectorAll("video").forEach((video) => {
+        video.attributes.removeNamedItem("poster");
+    });
+}

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -403,7 +403,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
         // on iOS 17 on the iPhone, the video starts with a black screen
         // if there's a poster attribute
         if #available(iOS 17, *), Device.current == .iPhone {
-            webView.evaluateJavaScript("removeVideoPosters();")
+            webView.evaluateJavaScript("fixVideoElements();")
         }
         webView.adjustTextSize()
 #else

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -114,6 +114,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
 
         // configure web view
         webView.allowsBackForwardNavigationGestures = true
+        webView.configuration.allowsInlineMediaPlayback = true
         webView.configuration.defaultWebpagePreferences.preferredContentMode = .mobile // for font adjustment to work
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "headings")
         webView.configuration.userContentController.add(self, name: "headings")

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -114,7 +114,6 @@ final class BrowserViewModel: NSObject, ObservableObject,
 
         // configure web view
         webView.allowsBackForwardNavigationGestures = true
-        webView.configuration.allowsInlineMediaPlayback = true
         webView.configuration.defaultWebpagePreferences.preferredContentMode = .mobile // for font adjustment to work
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "headings")
         webView.configuration.userContentController.add(self, name: "headings")

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -395,9 +395,15 @@ final class BrowserViewModel: NSObject, ObservableObject,
         decisionHandler(.allow)
     }
 
+    @MainActor
     func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
         webView.evaluateJavaScript("expandAllDetailTags(); getOutlineItems();")
 #if os(iOS)
+        // on iOS 17 on the iPhone, the video starts with a black screen
+        // if there's a poster attribute
+        if #available(iOS 17, *), Device.current == .iPhone {
+            webView.evaluateJavaScript("removeVideoPosterOniOS17();")
+        }
         webView.adjustTextSize()
 #else
         persistState()

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -402,7 +402,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
         // on iOS 17 on the iPhone, the video starts with a black screen
         // if there's a poster attribute
         if #available(iOS 17, *), Device.current == .iPhone {
-            webView.evaluateJavaScript("removeVideoPosterOniOS17();")
+            webView.evaluateJavaScript("removeVideoPosters();")
         }
         webView.adjustTextSize()
 #else


### PR DESCRIPTION
Fixes: #916 
It seems it is an iOS 17 iPhone bug:
if we have a poster attribute set, the video starts with a black screen.


## Content used:
Currently in the "New" section:
- [TED collective (31 Jul 2024)](https://download.kiwix.org/zim/ted/ted_mul_collective_2024-07.zim.meta4)
- [TED humanities (02 Aug 2024)](https://download.kiwix.org/zim/ted/ted_mul_humanities_2024-08.zim.meta4)

## Solution:
TLDR: Remove poster attribute on iPhone iOS 17.


## Remove the poster attribute and having a poster displayed:
Looking deeper inside the HTML content we are using, we have the following structures:

## TED "I hope" | iPhone 17.5 | BEFORE poster removal
```html
<div id="video-wrapper">
    <div id="vjs_video_3"
        data-setup="{&quot;techOrder&quot;: [&quot;html5&quot;, &quot;ogvjs&quot;], &quot;ogvjs&quot;: {&quot;base&quot;: &quot;assets/ogvjs&quot;}, &quot;autoplay&quot;: false, &quot;preload&quot;: true, &quot;controls&quot;: true, &quot;controlBar&quot;: {&quot;pictureInPictureToggle&quot;:false}}"
        poster="videos/87396/thumbnail.webp" playsinline="true" preload="auto"
        class="video-js vjs-default-skin vjs-fill vjs-paused vjs_video_3-dimensions vjs-controls-enabled vjs-touch-enabled vjs-v7 vjs-user-active"
        tabindex="-1" lang="en-gb" role="region" aria-label="Video Player"><video class="vjs-tech" preload="true"
            playsinline="playsinline" poster="videos/87396/thumbnail.webp"
            data-setup="{&quot;techOrder&quot;: [&quot;html5&quot;, &quot;ogvjs&quot;], &quot;ogvjs&quot;: {&quot;base&quot;: &quot;assets/ogvjs&quot;}, &quot;autoplay&quot;: false, &quot;preload&quot;: true, &quot;controls&quot;: true, &quot;controlBar&quot;: {&quot;pictureInPictureToggle&quot;:false}}"
            id="vjs_video_3_html5_api" tabindex="-1" src="videos/87396/video.webm">
            <source src="videos/87396/video.webm" type="video/webm">
        </video>
        <div class="vjs-poster" aria-disabled="false"
            style="background-image: url(&quot;videos/87396/thumbnail.webp&quot;);"></div>
</div>
```

## TED "I hope" | iPhone 17.5 | AFTER poster removal
```html
<div id="video-wrapper">
    <div id="vjs_video_3"
        data-setup="{&quot;techOrder&quot;: [&quot;html5&quot;, &quot;ogvjs&quot;], &quot;ogvjs&quot;: {&quot;base&quot;: &quot;assets/ogvjs&quot;}, &quot;autoplay&quot;: false, &quot;preload&quot;: true, &quot;controls&quot;: true, &quot;controlBar&quot;: {&quot;pictureInPictureToggle&quot;:false}}"
        poster="videos/87396/thumbnail.webp" playsinline="true" preload="auto"
        class="video-js vjs-default-skin vjs-fill vjs-paused vjs_video_3-dimensions vjs-controls-enabled vjs-touch-enabled vjs-v7 vjs-user-active"
        tabindex="-1" lang="en-gb" role="region" aria-label="Video Player"><video class="vjs-tech" preload="true"
            playsinline="playsinline"
            data-setup="{&quot;techOrder&quot;: [&quot;html5&quot;, &quot;ogvjs&quot;], &quot;ogvjs&quot;: {&quot;base&quot;: &quot;assets/ogvjs&quot;}, &quot;autoplay&quot;: false, &quot;preload&quot;: true, &quot;controls&quot;: true, &quot;controlBar&quot;: {&quot;pictureInPictureToggle&quot;:false}}"
            id="vjs_video_3_html5_api" tabindex="-1" src="videos/87396/video.webm">
            <source src="videos/87396/video.webm" type="video/webm">
        </video>
        <div class="vjs-poster" aria-disabled="false"
            style="background-image: url(&quot;videos/87396/thumbnail.webp&quot;);"></div>
</div>
```

TLDR: **the poster is set up in 3 different places**. Therefore removing the attribute from the video element only, is not causing any side effects, **the poster itself is still displayed, but we are fixing the black screen issue.**


## Dynamic contents:
Some of the ZIM files, such as [Deus ex silicium fr](https://mirror.download.kiwix.org/zim/videos/deus-ex-silicium_fr_all_2024-08.zim) also used in [the other issue](https://github.com/kiwix/kiwix-apple/issues/914), creates the `<video>` tag dynamically, eg. via VUE.js routing and XHR requests.

To "fix" the `<video>` tags in such dynamic cases, we can [observe](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) how the DOM is changing, and if a `<video>` tag was inserted we can run the same `removePoster` function on that.


