### PR TITLE
Fix library double sheet, by using a common state

### DIFF
--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -143,55 +143,55 @@ private struct CompactView: View {
                     // do nothing
                 }
             })
-            .id(tabID)
-            .toolbar {
-                ToolbarItemGroup(placement: .bottomBar) {
-                    Spacer()
-                    NavigationButtons()
-                    Spacer()
-                    OutlineButton()
-                    Spacer()
-                    BookmarkButton()
-                    Spacer()
-                    ExportButton()
-                    Spacer()
-                    TabsManagerButton()
-                    Spacer()
-                    if FeatureFlags.hasLibrary {
+                .id(tabID)
+                .toolbar {
+                    ToolbarItemGroup(placement: .bottomBar) {
+                        Spacer()
+                        NavigationButtons()
+                        Spacer()
+                        OutlineButton()
+                        Spacer()
+                        BookmarkButton()
+                        Spacer()
+                        ExportButton()
+                        Spacer()
+                        TabsManagerButton()
+                        Spacer()
+                        if FeatureFlags.hasLibrary {
+                            Button {
+                                presentedSheet = .library(nil)
+                            } label: {
+                                Label("common.tab.menu.library".localized, systemImage: "folder")
+                            }
+                            Spacer()
+                        }
                         Button {
-                            presentedSheet = .library(nil)
+                            presentedSheet = .settings
                         } label: {
-                            Label("common.tab.menu.library".localized, systemImage: "folder")
+                            Label("common.tab.menu.settings".localized, systemImage: "gear")
                         }
                         Spacer()
                     }
-                    Button {
-                        presentedSheet = .settings
-                    } label: {
-                        Label("common.tab.menu.settings".localized, systemImage: "gear")
-                    }
-                    Spacer()
                 }
-            }
-            .environmentObject(BrowserViewModel.getCached(tabID: tabID))
-            .sheet(item: $presentedSheet) { presentedSheet in
-                switch presentedSheet {
-                case .library(let tabItem):
-                    Library(dismiss: dismiss, tabItem: tabItem)
-                case .settings:
-                    NavigationView {
-                        Settings().toolbar {
-                            ToolbarItem(placement: .navigationBarLeading) {
-                                Button {
-                                    self.presentedSheet = nil
-                                } label: {
-                                    Text("common.button.done".localized).fontWeight(.semibold)
+                .environmentObject(BrowserViewModel.getCached(tabID: tabID))
+                .sheet(item: $presentedSheet) { presentedSheet in
+                    switch presentedSheet {
+                    case .library(let tabItem):
+                        Library(dismiss: dismiss, tabItem: tabItem)
+                    case .settings:
+                        NavigationView {
+                            Settings().toolbar {
+                                ToolbarItem(placement: .navigationBarLeading) {
+                                    Button {
+                                        self.presentedSheet = nil
+                                    } label: {
+                                        Text("common.button.done".localized).fontWeight(.semibold)
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
         }
     }
 }

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -15,6 +15,7 @@
 
 import SwiftUI
 
+/// This is macOS and iPad only specific, not used on iPhone
 struct BrowserTab: View {
     @EnvironmentObject private var browser: BrowserViewModel
     @StateObject private var search = SearchViewModel()
@@ -87,7 +88,7 @@ struct BrowserTab: View {
                             .environment(\.horizontalSizeClass, proxy.size.width > 750 ? .regular : .compact)
                             #endif
                     } else if browser.url == nil && FeatureFlags.hasLibrary {
-                        Welcome()
+                        Welcome(showLibrary: nil)
                     } else {
                         WebView().ignoresSafeArea()
                         #if os(macOS)

--- a/Views/Welcome.swift
+++ b/Views/Welcome.swift
@@ -29,7 +29,8 @@ struct Welcome: View {
         predicate: ZimFile.openedPredicate,
         animation: .easeInOut
     ) private var zimFiles: FetchedResults<ZimFile>
-    @State private var isLibraryPresented = false
+    /// Used only for iPhone
+    let showLibrary: (() -> Void)?
 
     var body: some View {
         if zimFiles.isEmpty {
@@ -59,15 +60,10 @@ struct Welcome: View {
                 if horizontalSizeClass == .regular {
                     navigation.currentItem = .categories
                 } else {
-                    isLibraryPresented = true
+                    showLibrary?()
                 }
                 #endif
             }
-            #if os(iOS)
-            .sheet(isPresented: $isLibraryPresented) {
-                Library(dismiss: { isLibraryPresented = false }, tabItem: .categories)
-            }
-            #endif
         } else {
             LazyVGrid(
                 columns: ([GridItem(.adaptive(minimum: 250, maximum: 500), spacing: 12)]),
@@ -152,7 +148,7 @@ struct Welcome: View {
 
 struct WelcomeView_Previews: PreviewProvider {
     static var previews: some View {
-        Welcome().environmentObject(LibraryViewModel()).preferredColorScheme(.light).padding()
-        Welcome().environmentObject(LibraryViewModel()).preferredColorScheme(.dark).padding()
+        Welcome(showLibrary: nil).environmentObject(LibraryViewModel()).preferredColorScheme(.light).padding()
+        Welcome(showLibrary: nil).environmentObject(LibraryViewModel()).preferredColorScheme(.dark).padding()
     }
 }


### PR DESCRIPTION
Fixes: #923 

## The issue:

We had 2 independent states, and 2 independent places on iPhone to open the `Library()`, which is a pop-up / sheet that presents the list of categories.

One could be triggered by the user, while the other could be triggered, when fetching the categories were completed.

## Solution:

Use a single state to indicate what sheet should be opened.
Additionally use a callback we can pass down, that is used to update this state, when the categories fetching is complete. Additionally only update the state, if there are no sheets presented. 

