### PR TITLE
922 my library is outdated 2 months old despite having checked to update automatically

### DIFF
--- a/App/App_iOS.swift
+++ b/App/App_iOS.swift
@@ -28,7 +28,6 @@ struct Kiwix: App {
 
     init() {
         fileMonitor = DirectoryMonitor(url: URL.documentDirectory) { LibraryOperations.scanDirectory($0) }
-        LibraryOperations.registerBackgroundTask()
         UNUserNotificationCenter.current().delegate = appDelegate
     }
 
@@ -63,7 +62,6 @@ struct Kiwix: App {
                         }
                         LibraryOperations.scanDirectory(URL.documentDirectory)
                         LibraryOperations.applyFileBackupSetting()
-                        LibraryOperations.applyLibraryAutoRefreshSetting()
                         DownloadService.shared.restartHeartbeatIfNeeded()
                     case let .custom(zimFileURL):
                         LibraryOperations.open(url: zimFileURL) {

--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -34,6 +34,9 @@ struct Kiwix: App {
 
     init() {
         UNUserNotificationCenter.current().delegate = notificationCenterDelegate
+        if FeatureFlags.hasLibrary {
+            LibraryViewModel().start(isUserInitiated: false)
+        }
     }
 
     var body: some Scene {

--- a/Support/Info.plist
+++ b/Support/Info.plist
@@ -37,8 +37,6 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
-		<string>fetch</string>
-		<string>processing</string>
 	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>

--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -107,6 +107,7 @@
 "zim_file_opened.toolbar.open.help" = "Open a ZIM file";
 "zim_file_category.title" = "Category";
 
+"zim_file_catalog.fetching.message" = "Fetching Catalog ...";
 "zim_file_category.section.empty.message" = "No ZIM file under this category.";
 "zim_file_downloads.overlay.empty.message" = "No download tasks";
 "zim_file_downloads.toolbar.show_sidebar.label" = "Show Sidebar";

--- a/Support/qqq.lproj/Localizable.strings
+++ b/Support/qqq.lproj/Localizable.strings
@@ -69,6 +69,7 @@
 "zim_file_opened.toolbar.open.title" = "Accesissiblit label of a (+) icon on iOS, in the top right corner, to open a local file";
 "zim_file_opened.toolbar.open.help" = "Accessibility label of a (+) icon in the macOS app, in the top right corner, to open a local file";
 "zim_file_category.title" = "Accessiblity label for category picker";
+"zim_file_catalog.fetching.message" = "Fallback text for the case when the catalog of ZIM files is still being refreshed, and it will appear soon, as the operation completes.";
 "zim_file_category.section.empty.message" = "Fallback text for listing results";
 "zim_file_downloads.overlay.empty.message" = "Fallback text for center panel, when downloads are selected from the side menu.";
 "zim_file_downloads.toolbar.show_sidebar.label" = "Accessibility label for side bar toggle button";

--- a/SwiftUI/Model/LibraryOperations.swift
+++ b/SwiftUI/Model/LibraryOperations.swift
@@ -24,8 +24,6 @@ import Defaults
 struct LibraryOperations {
     private init() {}
 
-    static let backgroundTaskIdentifier = "org.kiwix.library_refresh"
-
     // MARK: - Open
 
     /// Open a zim file with url
@@ -194,35 +192,4 @@ struct LibraryOperations {
             )
         } catch {}
     }
-
-#if os(iOS)
-    // MARK: - Background Refresh
-
-    /// Apply library background refresh setting.
-    /// - Parameter isEnabled: if library should be refreshed on background
-    static func applyLibraryAutoRefreshSetting(isEnabled: Bool? = nil) {
-        if isEnabled ?? Defaults[.libraryAutoRefresh] {
-            let request = BGAppRefreshTaskRequest(identifier: LibraryOperations.backgroundTaskIdentifier)
-            if let lastRefreshData = Defaults[.libraryLastRefresh] {
-                request.earliestBeginDate = Date(timeInterval: 3600 * 24, since: lastRefreshData)
-            }
-            try? BGTaskScheduler.shared.submit(request)
-            os_log("Enabling background library refresh.", log: Log.LibraryOperations, type: .info)
-        } else {
-            BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: LibraryOperations.backgroundTaskIdentifier)
-            os_log("Disabling background library refresh.", log: Log.LibraryOperations, type: .info)
-        }
-    }
-
-    static func registerBackgroundTask() {
-        BGTaskScheduler.shared.register(
-            forTaskWithIdentifier: LibraryOperations.backgroundTaskIdentifier, using: nil
-        ) { task in
-            Task {
-                await LibraryViewModel().start(isUserInitiated: false)
-                task.setTaskCompleted(success: true)
-            }
-        }
-    }
-#endif
 }

--- a/Tests/LibraryRefreshViewModelTest.swift
+++ b/Tests/LibraryRefreshViewModelTest.swift
@@ -20,7 +20,7 @@ import Defaults
 @testable import Kiwix
 
 private class HTTPTestingURLProtocol: URLProtocol {
-    static var handler: ((URLProtocol) -> Void)? = nil
+    static var handler: ((URLProtocol) -> Void)?
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
@@ -97,7 +97,8 @@ final class LibraryRefreshViewModelTest: XCTestCase {
             urlProtocol.client?.urlProtocol(urlProtocol, didFailWithError: URLError(URLError.Code.timedOut))
         }
 
-        let viewModel = LibraryViewModel(urlSession: urlSession)
+        let viewModel = LibraryViewModel(urlSession: urlSession,
+                                         processFactory: { LibraryProcess() })
         await viewModel.start(isUserInitiated: true)
         XCTAssert(viewModel.error is LibraryRefreshError)
         XCTAssertEqual(
@@ -118,7 +119,8 @@ final class LibraryRefreshViewModelTest: XCTestCase {
             urlProtocol.client?.urlProtocolDidFinishLoading(urlProtocol)
         }
 
-        let viewModel = LibraryViewModel(urlSession: urlSession)
+        let viewModel = LibraryViewModel(urlSession: urlSession,
+                                         processFactory: { LibraryProcess() })
         await viewModel.start(isUserInitiated: true)
         XCTAssert(viewModel.error is LibraryRefreshError)
         XCTAssertEqual(
@@ -140,7 +142,8 @@ final class LibraryRefreshViewModelTest: XCTestCase {
             urlProtocol.client?.urlProtocolDidFinishLoading(urlProtocol)
         }
 
-        let viewModel = LibraryViewModel(urlSession: urlSession)
+        let viewModel = LibraryViewModel(urlSession: urlSession,
+                                         processFactory: { LibraryProcess() })
         await viewModel.start(isUserInitiated: true)
         XCTExpectFailure("Requires work in dependency to resolve the issue.")
         XCTAssertEqual(
@@ -164,7 +167,8 @@ final class LibraryRefreshViewModelTest: XCTestCase {
             urlProtocol.client?.urlProtocolDidFinishLoading(urlProtocol)
         }
 
-        let viewModel = LibraryViewModel(urlSession: urlSession)
+        let viewModel = LibraryViewModel(urlSession: urlSession,
+                                         processFactory: { LibraryProcess() })
         await viewModel.start(isUserInitiated: true)
 
         // check no error has happened
@@ -213,7 +217,8 @@ final class LibraryRefreshViewModelTest: XCTestCase {
     @MainActor
     func testZimFileDeprecation() async throws {
         // refresh library for the first time, which should create one zim file
-        let viewModel = LibraryViewModel(urlSession: urlSession)
+        let viewModel = LibraryViewModel(urlSession: urlSession,
+                                         processFactory: { LibraryProcess() })
         await viewModel.start(isUserInitiated: true)
         let context = Database.shared.viewContext
         let zimFile1 = try XCTUnwrap(try context.fetch(ZimFile.fetchRequest()).first)

--- a/Views/Library/ZimFilesCategories.swift
+++ b/Views/Library/ZimFilesCategories.swift
@@ -52,6 +52,8 @@ struct ZimFilesCategories: View {
                         }
                     }
                 }
+            }.onAppear {
+                LibraryViewModel().start(isUserInitiated: false)
             }
     }
 }
@@ -117,7 +119,11 @@ private struct CategoryGrid: View {
     var body: some View {
         Group {
             if sections.isEmpty {
-                Message(text: "zim_file_category.section.empty.message".localized)
+                if viewModel.state == .inProgress {
+                    Message(text: "zim_file_catalog.fetching.message".localized)
+                } else {
+                    Message(text: "zim_file_category.section.empty.message".localized)
+                }
             } else {
                 LazyVGrid(columns: ([gridItem]), alignment: .leading, spacing: 12) {
                     ForEach(sections) { section in
@@ -218,7 +224,11 @@ private struct CategoryList: View {
     var body: some View {
         Group {
             if zimFiles.isEmpty {
-                Message(text: "zim_file_category.section.empty.message".localized)
+                if viewModel.state == .inProgress {
+                    Message(text: "zim_file_catalog.fetching.message".localized)
+                } else {
+                    Message(text: "zim_file_category.section.empty.message".localized)
+                }
             } else {
                 List(zimFiles, id: \.self, selection: $viewModel.selectedZimFile) { zimFile in
                     ZimFileRow(zimFile)

--- a/Views/Library/ZimFilesNew.swift
+++ b/Views/Library/ZimFilesNew.swift
@@ -60,7 +60,11 @@ struct ZimFilesNew: View {
         }
         .overlay {
             if zimFiles.isEmpty {
-                Message(text: "zim_file_new_overlay.empty".localized)
+                if viewModel.state == .inProgress {
+                    Message(text: "zim_file_catalog.fetching.message".localized)
+                } else {
+                    Message(text: "zim_file_new_overlay.empty".localized)
+                }
             }
         }
         .toolbar {

--- a/Views/Settings/Settings.swift
+++ b/Views/Settings/Settings.swift
@@ -220,7 +220,7 @@ struct Settings: View {
             Text("catalog_settings.header.text".localized)
         } footer: {
             Text("catalog_settings.footer.text".localized)
-        }.onChange(of: libraryAutoRefresh) { LibraryOperations.applyLibraryAutoRefreshSetting(isEnabled: $0) }
+        }
     }
 
     var backupSettings: some View {


### PR DESCRIPTION
Fixes: #922 

Summary of changes:
- remove background processing / background fetching for iOS
- since we no longer scheduling background task, those permissions were also removed

- auto update works in the following way: 
- If enabled we will check if the library should be re-fetched (meaning it's older than 1 day), in the following cases:
- the user foregrounds the app (either when starting the app, or background + foreground), on macOS it's the moment of the app starting
- the user visits either the "New" or "Categories" sections
- additionally we update the displayed messages while fetching, so instead of "No new ZIM Files" we indicate that we are still "Fetching..."


I've added some additional safeguard for the app start / foregrounding, as on Custom apps we do not need to fetch categories if they are not included, the sections "New" and "Categories" are turned off on those apps, so that's OK.