### PR TITLE
933 iphone video starts in full screen

### DIFF
--- a/Support/injection.js
+++ b/Support/injection.js
@@ -95,6 +95,7 @@ function fixVideoElements() {
             if(attributes.getNamedItem('poster')) {
                 attributes.removeNamedItem('poster');
             }
+            video.setAttribute('playsinline', '');
         });
     }
 

--- a/Views/BuildingBlocks/WebView.swift
+++ b/Views/BuildingBlocks/WebView.swift
@@ -227,6 +227,9 @@ final class WebViewConfiguration: WKWebViewConfiguration {
         setURLSchemeHandler(KiwixURLSchemeHandler(), forURLScheme: KiwixURLSchemeHandler.KiwixScheme)
         #if os(macOS)
         preferences.isElementFullscreenEnabled = true
+        #else
+        allowsInlineMediaPlayback = true
+        mediaTypesRequiringUserActionForPlayback = []
         #endif
         userContentController = {
             let controller = WKUserContentController()


### PR DESCRIPTION
Fixes: #933 

Note it is based on the PR: https://github.com/kiwix/kiwix-apple/pull/924

## Solution:

As of [Apple's doc](https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/1614793-allowsinlinemediaplayback), we need to set:
``allowsinlinemediaplayback``
and additionally set:
``mediaTypesRequiringUserActionForPlayback`` - otherwise it's not working
and we need to enforce that there's a ``playsinline`` attribute on the html `<video>`.