### PR TITLE
Fix Blank item in search results

### DIFF
--- a/Model/Entities/SearchResult.h
+++ b/Model/Entities/SearchResult.h
@@ -28,7 +28,5 @@
 - (nullable instancetype)initWithZimFileID:(nonnull NSUUID *)zimFileID
                                       path:(nonnull NSString *)path
                                      title:(nonnull NSString *)title;
-- (BOOL)isEqual:(nullable id)other;
-- (NSUInteger)hash;
 
 @end

--- a/Model/Entities/SearchResult.m
+++ b/Model/Entities/SearchResult.m
@@ -39,18 +39,4 @@
     return self;
 }
 
-- (BOOL)isEqual:(id)other {
-    if (other == self) {
-        return YES;
-    } else if ([other isKindOfClass:self.class]) {
-        return [self.url isEqual:((SearchResult *)other).url];
-    } else {
-        return [super isEqual:other];
-    }
-}
-
-- (NSUInteger)hash {
-    return self.url.hash;
-}
-
 @end

--- a/SwiftUI/Model/SearchOperation/SearchOperation.swift
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.swift
@@ -26,29 +26,23 @@ extension SearchOperation {
         // parse and extract search result snippet
         guard !isCancelled else { return }
         let snippetMode = Defaults[.searchResultSnippetMode]
-        let dispatchGroup = DispatchGroup()
         for result in results {
-            dispatchGroup.enter()
-            DispatchQueue.global(qos: .userInitiated).async {
-                defer { dispatchGroup.leave() }
-                guard !self.isCancelled else { return }
+            guard !self.isCancelled else { return }
 
-                switch snippetMode {
-                case .matches:
-                    guard let html = result.htmlSnippet,
-                          let data = html.data(using: .utf8) else { return }
-                    result.snippet = try? NSAttributedString(
-                        data: data,
-                        options: [.documentType: NSAttributedString.DocumentType.html,
-                                  .characterEncoding: String.Encoding.utf8.rawValue],
-                        documentAttributes: nil
-                    )
-                case .disabled:
-                    break
-                }
+            switch snippetMode {
+            case .matches:
+                guard let html = result.htmlSnippet,
+                      let data = html.data(using: .utf8) else { return }
+                result.snippet = try? NSAttributedString(
+                    data: data,
+                    options: [.documentType: NSAttributedString.DocumentType.html,
+                              .characterEncoding: String.Encoding.utf8.rawValue],
+                    documentAttributes: nil
+                )
+            case .disabled:
+                break
             }
         }
-        dispatchGroup.wait()
 
         // start sorting search results
         guard !isCancelled else { return }

--- a/SwiftUI/Model/SearchOperation/SearchOperation.swift
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.swift
@@ -23,7 +23,6 @@ extension SearchOperation {
         guard !searchText.isEmpty else { return }
         performSearch()
 
-        guard !isCancelled else { return }
         // reduce to unique results by id
         let uniqueDict = Dictionary(grouping: results, by: { $0.id })
         let values = uniqueDict.compactMapValues { $0.first }.values
@@ -32,7 +31,6 @@ extension SearchOperation {
         // parse and extract search result snippet
         if case .matches = Defaults[.searchResultSnippetMode] {
             for result in results {
-                guard !self.isCancelled else { return }
                 guard let html = result.htmlSnippet,
                       let data = html.data(using: .utf8) else { return }
                 result.snippet = try? NSAttributedString(
@@ -45,8 +43,7 @@ extension SearchOperation {
         }
 
         // start sorting search results
-        guard !isCancelled else { return }
-        let searchText = self.searchText.lowercased()
+        let searchText = searchText.lowercased()
 
         // calculate score for all results
         for result in results {

--- a/ViewModel/SearchViewModel.swift
+++ b/ViewModel/SearchViewModel.swift
@@ -15,7 +15,7 @@
 
 import Combine
 import CoreData
-import QuartzCore
+
 import Defaults
 
 class SearchViewModel: NSObject, ObservableObject, NSFetchedResultsControllerDelegate {
@@ -71,7 +71,6 @@ class SearchViewModel: NSObject, ObservableObject, NSFetchedResultsControllerDel
     }
 
     private func updateSearchResults(_ searchText: String, _ zimFileIDs: Set<UUID>) {
-        let start = CACurrentMediaTime()
         queue.cancelAllOperations()
         let operation = SearchOperation(searchText: searchText, zimFileIDs: zimFileIDs)
         operation.extractMatchingSnippet = Defaults[.searchResultSnippetMode] == .matches
@@ -80,8 +79,6 @@ class SearchViewModel: NSObject, ObservableObject, NSFetchedResultsControllerDel
             DispatchQueue.main.sync {
                 self?.results = operation.results
                 self?.inProgress = false
-                let end = CACurrentMediaTime() - start
-                debugPrint("searching for \"\(searchText)\" took: \(end)")
             }
         }
         queue.addOperation(operation)

--- a/ViewModel/SearchViewModel.swift
+++ b/ViewModel/SearchViewModel.swift
@@ -15,7 +15,7 @@
 
 import Combine
 import CoreData
-
+import QuartzCore
 import Defaults
 
 class SearchViewModel: NSObject, ObservableObject, NSFetchedResultsControllerDelegate {
@@ -71,6 +71,7 @@ class SearchViewModel: NSObject, ObservableObject, NSFetchedResultsControllerDel
     }
 
     private func updateSearchResults(_ searchText: String, _ zimFileIDs: Set<UUID>) {
+        let start = CACurrentMediaTime()
         queue.cancelAllOperations()
         let operation = SearchOperation(searchText: searchText, zimFileIDs: zimFileIDs)
         operation.extractMatchingSnippet = Defaults[.searchResultSnippetMode] == .matches
@@ -79,6 +80,8 @@ class SearchViewModel: NSObject, ObservableObject, NSFetchedResultsControllerDel
             DispatchQueue.main.sync {
                 self?.results = operation.results
                 self?.inProgress = false
+                let end = CACurrentMediaTime() - start
+                debugPrint("searching for \"\(searchText)\" took: \(end)")
             }
         }
         queue.addOperation(operation)


### PR DESCRIPTION
Fixes: #940 

The issue was mainly that if we had the same url for the search result, but with different snippets, that created the same id for both, and one of them could not be rendered, because of this conflict.
It's safer to use the hash of full object, rather than the url's hash only, plus it's better to reduce the search results by the same id, before we process them any further.

I did simplify some of the loops around the search results processing, which made the search teeny-tiny faster.

Since we no longer do html parsing, the dispatchGroup solution is no longer needed, it just creates a lot of context switches between the threads, and it's actually measurably slower than without it.