### PR TITLE
Fix search bar inconsistencies on iPhone

### DIFF
--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -104,6 +104,7 @@ final class CompactViewController: UIHostingController<AnyView>, UISearchControl
     func willDismissSearchController(_ searchController: UISearchController) {
         navigationController?.setToolbarHidden(false, animated: true)
         searchViewModel.searchText = ""
+        navigationItem.trailingItemGroups = trailingNavItemGroups
     }
 
     func updateSearchResults(for searchController: UISearchController) {

--- a/ViewModel/SearchViewModel.swift
+++ b/ViewModel/SearchViewModel.swift
@@ -20,7 +20,6 @@ import Defaults
 
 class SearchViewModel: NSObject, ObservableObject, NSFetchedResultsControllerDelegate {
     @Published var searchText: String = ""  // text in the search field
-    @Published var isSearching = false  // for iOS 15 & 14
     @Published private(set) var zimFiles: [UUID: ZimFile]  // ID of zim files that are included in search
     @Published private(set) var inProgress = false
     @Published private(set) var results = [SearchResult]()

--- a/ViewModel/SearchViewModel.swift
+++ b/ViewModel/SearchViewModel.swift
@@ -18,7 +18,7 @@ import CoreData
 
 import Defaults
 
-class SearchViewModel: NSObject, ObservableObject, NSFetchedResultsControllerDelegate {
+final class SearchViewModel: NSObject, ObservableObject, NSFetchedResultsControllerDelegate {
     @Published var searchText: String = ""  // text in the search field
     @Published private(set) var zimFiles: [UUID: ZimFile]  // ID of zim files that are included in search
     @Published private(set) var inProgress = false


### PR DESCRIPTION
Fixes: #946 

## Root cause:
We store the button tab items when the search starts, and restore them when the search is cancelled. While the problem is that we should also restore them if the search succeeds, and we navigate away.