### PR TITLE
Remove search clear dialog, as it's crashing on iPadOS 17.5

### DIFF
--- a/Support/br.lproj/Localizable.strings
+++ b/Support/br.lproj/Localizable.strings
@@ -133,7 +133,6 @@
 "search_result.sidebar.button.remove" = "Dilemel";
 "search_result.header.text" = "Klasket nevez zo";
 "search_result.button.clear" = "Riñsañ";
-"search_result.clear_dialog.button.all" = "Diverkañ pep tra";
 "search_result.filter_hearder.button.none" = "Hini ebet";
 "search_result.filter_hearder.button.all" = "Pep tra";
 "welcome.main_page.title" = "Degemer";

--- a/Support/de.lproj/Localizable.strings
+++ b/Support/de.lproj/Localizable.strings
@@ -184,9 +184,6 @@
 "search_result.sidebar.button.remove" = "Entfernen";
 "search_result.header.text" = "Letzte Suche";
 "search_result.button.clear" = "Löschen";
-"search_result.clear_dialog.title" = "Letzte Suchanfragen löschen";
-"search_result.clear_dialog.button.all" = "Alle löschen";
-"search_result.clear_dialog.description" = "Der gesamte aktuelle Suchverlauf wird entfernt.";
 "search_result.filter_hearder.text" = "In der Suche enthalten";
 "search_result.filter_hearder.button.none" = "Nichts";
 "search_result.filter_hearder.button.all" = "Alles";

--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -216,9 +216,6 @@
 "search_result.sidebar.button.remove" = "Remove";
 "search_result.header.text" = "Recent Search";
 "search_result.button.clear" = "Clear";
-"search_result.clear_dialog.title" = "Clear Recent Searches";
-"search_result.clear_dialog.button.all" = "Clear All";
-"search_result.clear_dialog.description" = "All recent search history will be removed.";
 "search_result.filter_hearder.text" = "Included in Search";
 "search_result.filter_hearder.button.none" = "None";
 "search_result.filter_hearder.button.all" = "All";

--- a/Support/fi.lproj/Localizable.strings
+++ b/Support/fi.lproj/Localizable.strings
@@ -99,8 +99,6 @@
 "search_result.sidebar.button.remove" = "Poista";
 "search_result.header.text" = "Viimeisin haku";
 "search_result.button.clear" = "Tyhjennä";
-"search_result.clear_dialog.title" = "Tyhjennä viimeisimmät haut";
-"search_result.clear_dialog.button.all" = "Tyhjennä kaikki";
 "search_result.filter_hearder.button.all" = "Kaikki";
 "welcome.main_page.title" = "Etusivu";
 "welcome.grid.bookmarks.title" = "Kirjanmerkit";

--- a/Support/fr.lproj/Localizable.strings
+++ b/Support/fr.lproj/Localizable.strings
@@ -187,9 +187,6 @@
 "search_result.sidebar.button.remove" = "Retirer";
 "search_result.header.text" = "Recherche récente";
 "search_result.button.clear" = "Effacer";
-"search_result.clear_dialog.title" = "Effacer les recherches récentes";
-"search_result.clear_dialog.button.all" = "Effacer tout";
-"search_result.clear_dialog.description" = "Tout l’historique de recherche récent sera supprimé.";
 "search_result.filter_hearder.text" = "Inclus dans la recherche";
 "search_result.filter_hearder.button.none" = "Aucun";
 "search_result.filter_hearder.button.all" = "Tous";

--- a/Support/ha.lproj/Localizable.strings
+++ b/Support/ha.lproj/Localizable.strings
@@ -175,9 +175,6 @@
 "search_result.sidebar.button.remove" = "Cire";
 "search_result.header.text" = "Bincike na baya-baya:";
 "search_result.button.clear" = "Share";
-"search_result.clear_dialog.title" = "Share binciken baya-bayan nan";
-"search_result.clear_dialog.button.all" = "Share Duk";
-"search_result.clear_dialog.description" = "Za a cire duk tarihin binciken kwanan nan.";
 "search_result.filter_hearder.text" = "Kunshe cikin Bincike";
 "search_result.filter_hearder.button.none" = "Babu";
 "search_result.filter_hearder.button.all" = "Duka";

--- a/Support/he.lproj/Localizable.strings
+++ b/Support/he.lproj/Localizable.strings
@@ -177,9 +177,6 @@
 "search_result.sidebar.button.remove" = "הסרה";
 "search_result.header.text" = "חיפוש אחרון";
 "search_result.button.clear" = "ניקוי";
-"search_result.clear_dialog.title" = "ניקוי החיפושים האחרונים";
-"search_result.clear_dialog.button.all" = "ניקוי הכול";
-"search_result.clear_dialog.description" = "כל היסטוריית החיפושים האחרונה תוסר.";
 "search_result.filter_hearder.text" = "כלול בחיפוש";
 "search_result.filter_hearder.button.none" = "אין";
 "search_result.filter_hearder.button.all" = "הכול";

--- a/Support/hi.lproj/Localizable.strings
+++ b/Support/hi.lproj/Localizable.strings
@@ -59,7 +59,6 @@
 "settings.about.source.title" = "स्रोत";
 "bookmark.navigation.title" = "बुकमार्क";
 "search_result.button.clear" = "खाली करें";
-"search_result.clear_dialog.button.all" = "सभी साफ करें";
 "search_result.filter_hearder.button.none" = "कोई नहीं";
 "search_result.filter_hearder.button.all" = "सभी";
 "welcome.main_page.title" = "मुखपृष्ठ";

--- a/Support/ia.lproj/Localizable.strings
+++ b/Support/ia.lproj/Localizable.strings
@@ -175,9 +175,6 @@
 "search_result.sidebar.button.remove" = "Remover";
 "search_result.header.text" = "Recerca recente";
 "search_result.button.clear" = "Rader";
-"search_result.clear_dialog.title" = "Rader le recercas recente";
-"search_result.clear_dialog.button.all" = "Rader totes";
-"search_result.clear_dialog.description" = "Tote le historia de recercas recente essera eliminate.";
 "search_result.filter_hearder.text" = "Includite in recerca";
 "search_result.filter_hearder.button.none" = "Necun";
 "search_result.filter_hearder.button.all" = "Totes";

--- a/Support/ig.lproj/Localizable.strings
+++ b/Support/ig.lproj/Localizable.strings
@@ -185,9 +185,6 @@
 "search_result.sidebar.button.remove" = "Wepụ";
 "search_result.header.text" = "Ọchụchọ na nso nso a";
 "search_result.button.clear" = "Kpochapụ";
-"search_result.clear_dialog.title" = "Kpochapụ ọchụchọ ndị na-adịbeghị anya";
-"search_result.clear_dialog.button.all" = "Kpochapụ ihe niile";
-"search_result.clear_dialog.description" = "A ga-ewepụ akụkọ ọchụchọ niile na nso nso a.";
 "search_result.filter_hearder.text" = "Agụnyere na Ọchụchọ";
 "search_result.filter_hearder.button.none" = "Efù";
 "search_result.filter_hearder.button.all" = "Haníle";

--- a/Support/ja.lproj/Localizable.strings
+++ b/Support/ja.lproj/Localizable.strings
@@ -178,9 +178,6 @@
 "search_result.sidebar.button.remove" = "削除";
 "search_result.header.text" = "最近の検索";
 "search_result.button.clear" = "消去";
-"search_result.clear_dialog.title" = "最近の検索を消去";
-"search_result.clear_dialog.button.all" = "すべてクリア";
-"search_result.clear_dialog.description" = "最近の検索履歴が全て削除されます。";
 "search_result.filter_hearder.text" = "検索対象";
 "search_result.filter_hearder.button.none" = "無し";
 "search_result.filter_hearder.button.all" = "全て";

--- a/Support/ln.lproj/Localizable.strings
+++ b/Support/ln.lproj/Localizable.strings
@@ -31,8 +31,6 @@
 "search_result.sidebar.button.remove" = "Kolongola";
 "search_result.header.text" = "Boluki ya sika";
 "search_result.button.clear" = "Kolongola";
-"search_result.clear_dialog.title" = "Bolongola Boluki ya sika";
-"search_result.clear_dialog.button.all" = "Longola nyoso";
 "search_result.filter_hearder.text" = "Na kati ya bolukiluki";
 "search_result.filter_hearder.button.none" = "Mɔ́kɔ́ tɛ́";
 "search_result.filter_hearder.button.all" = "Nyɔ́nsɔ";

--- a/Support/mk.lproj/Localizable.strings
+++ b/Support/mk.lproj/Localizable.strings
@@ -176,9 +176,6 @@
 "search_result.sidebar.button.remove" = "Отстрани";
 "search_result.header.text" = "Скорешни пребарувања";
 "search_result.button.clear" = "Исчисти";
-"search_result.clear_dialog.title" = "Исчисти скорешни пребарувања";
-"search_result.clear_dialog.button.all" = "Исчисти сè";
-"search_result.clear_dialog.description" = "Ќе бидат отстранети сите скорешни пребарувања од историјата.";
 "search_result.filter_hearder.text" = "Вклучено во пребарувањето";
 "search_result.filter_hearder.button.none" = "Ништо";
 "search_result.filter_hearder.button.all" = "Сите";

--- a/Support/pl.lproj/Localizable.strings
+++ b/Support/pl.lproj/Localizable.strings
@@ -129,8 +129,6 @@
 "search_result.sidebar.button.remove" = "Usuń";
 "search_result.header.text" = "Ostatnie wyszukiwanie";
 "search_result.button.clear" = "Wyczyść";
-"search_result.clear_dialog.title" = "Wyczyść ostatnie wyszukiwania";
-"search_result.clear_dialog.button.all" = "Wyczyść wszystko";
 "search_result.filter_hearder.button.none" = "Żadne";
 "search_result.filter_hearder.button.all" = "Wszystkie";
 "welcome.main_page.title" = "Strona główna";

--- a/Support/ru.lproj/Localizable.strings
+++ b/Support/ru.lproj/Localizable.strings
@@ -180,9 +180,6 @@
 "search_result.sidebar.button.remove" = "Удалить";
 "search_result.header.text" = "Недавний поиск";
 "search_result.button.clear" = "Очистить";
-"search_result.clear_dialog.title" = "Очистить список последних поисковых запросов";
-"search_result.clear_dialog.button.all" = "Очистить все";
-"search_result.clear_dialog.description" = "Вся недавняя история поиска будет удалена.";
 "search_result.filter_hearder.text" = "Включено в поиск";
 "search_result.filter_hearder.button.none" = "Нет";
 "search_result.filter_hearder.button.all" = "Все";

--- a/Support/skr-arab.lproj/Localizable.strings
+++ b/Support/skr-arab.lproj/Localizable.strings
@@ -91,7 +91,6 @@
 "search_result.sidebar.button.remove" = "ہٹاؤ";
 "search_result.header.text" = "حالیہ ڳول";
 "search_result.button.clear" = "صاف";
-"search_result.clear_dialog.button.all" = "سارے صاف کرو";
 "search_result.filter_hearder.button.none" = "کوئی وی کائنی";
 "search_result.filter_hearder.button.all" = "یکے";
 "welcome.main_page.title" = "پہلا پرت";

--- a/Support/sl.lproj/Localizable.strings
+++ b/Support/sl.lproj/Localizable.strings
@@ -173,9 +173,6 @@
 "search_result.sidebar.button.remove" = "Odstrani";
 "search_result.header.text" = "Nedavna iskanja";
 "search_result.button.clear" = "Počisti";
-"search_result.clear_dialog.title" = "Počisti nedavna iskanja";
-"search_result.clear_dialog.button.all" = "Počisti vse";
-"search_result.clear_dialog.description" = "Odstranjena bo vsa nedavna zgodovina iskanja.";
 "search_result.filter_hearder.text" = "Vključeno v iskanje";
 "search_result.filter_hearder.button.none" = "Nič";
 "search_result.filter_hearder.button.all" = "Vse";

--- a/Support/sv.lproj/Localizable.strings
+++ b/Support/sv.lproj/Localizable.strings
@@ -178,9 +178,6 @@
 "search_result.sidebar.button.remove" = "Ta bort";
 "search_result.header.text" = "Senaste sökning";
 "search_result.button.clear" = "Rensa";
-"search_result.clear_dialog.title" = "Rensa senaste sökningar";
-"search_result.clear_dialog.button.all" = "Rensa allt";
-"search_result.clear_dialog.description" = "All senaste sökhistorik kommer att tas bort.";
 "search_result.filter_hearder.text" = "Inkluderas i sökning";
 "search_result.filter_hearder.button.none" = "Ingen";
 "search_result.filter_hearder.button.all" = "Alla";

--- a/Support/tr.lproj/Localizable.strings
+++ b/Support/tr.lproj/Localizable.strings
@@ -181,9 +181,6 @@
 "search_result.sidebar.button.remove" = "Kaldır";
 "search_result.header.text" = "Son Arama";
 "search_result.button.clear" = "Temizle";
-"search_result.clear_dialog.title" = "Son Aramaları Temizle";
-"search_result.clear_dialog.button.all" = "Tümünü Temizle";
-"search_result.clear_dialog.description" = "Son arama geçmişinin tümü kaldırılacak.";
 "search_result.filter_hearder.text" = "Aramaya dahil edildi";
 "search_result.filter_hearder.button.none" = "Hiçbiri";
 "search_result.filter_hearder.button.all" = "Hepsi";

--- a/Support/uk.lproj/Localizable.strings
+++ b/Support/uk.lproj/Localizable.strings
@@ -157,9 +157,6 @@
 "search_result.sidebar.button.remove" = "Видалити";
 "search_result.header.text" = "Недавні пошукові запити";
 "search_result.button.clear" = "Очистити";
-"search_result.clear_dialog.title" = "Очистити історію пошуку";
-"search_result.clear_dialog.button.all" = "Видалити все";
-"search_result.clear_dialog.description" = "Усю недавню історію пошуку буде видалено.";
 "search_result.filter_hearder.text" = "Включено в пошук";
 "search_result.filter_hearder.button.none" = "Жоден";
 "search_result.filter_hearder.button.all" = "Усі";

--- a/Support/zh-hans.lproj/Localizable.strings
+++ b/Support/zh-hans.lproj/Localizable.strings
@@ -178,9 +178,6 @@
 "search_result.sidebar.button.remove" = "移除";
 "search_result.header.text" = "最近搜索";
 "search_result.button.clear" = "清除";
-"search_result.clear_dialog.title" = "清除最近搜索";
-"search_result.clear_dialog.button.all" = "全部清除";
-"search_result.clear_dialog.description" = "所有最近的搜索历史记录将被删除。";
 "search_result.filter_hearder.text" = "包含在搜索中";
 "search_result.filter_hearder.button.none" = "无";
 "search_result.filter_hearder.button.all" = "全部";

--- a/Support/zh-hant.lproj/Localizable.strings
+++ b/Support/zh-hant.lproj/Localizable.strings
@@ -178,9 +178,6 @@
 "search_result.sidebar.button.remove" = "移除";
 "search_result.header.text" = "最近搜尋";
 "search_result.button.clear" = "清除";
-"search_result.clear_dialog.title" = "清除最近搜尋";
-"search_result.clear_dialog.button.all" = "全部清除";
-"search_result.clear_dialog.description" = "將會移除全部的最近搜尋歷史。";
 "search_result.filter_hearder.text" = "包含在搜尋中";
 "search_result.filter_hearder.button.none" = "無";
 "search_result.filter_hearder.button.all" = "全部";

--- a/Views/SearchResults.swift
+++ b/Views/SearchResults.swift
@@ -28,7 +28,6 @@ struct SearchResults: View {
         predicate: ZimFile.Predicate.isDownloaded,
         animation: .easeInOut
     ) private var zimFiles: FetchedResults<ZimFile>
-    @State private var isClearSearchConfirmationPresented = false
 
     private let openURL = NotificationCenter.default.publisher(for: .openURL)
 
@@ -138,16 +137,9 @@ struct SearchResults: View {
             Text("search_result.header.text".localized)
             Spacer()
             Button {
-                isClearSearchConfirmationPresented = true
+                recentSearchTexts.removeAll()
             } label: {
                 Text("search_result.button.clear".localized).font(.caption).fontWeight(.medium)
-            }.confirmationDialog("search_result.clear_dialog.title".localized,
-                                 isPresented: $isClearSearchConfirmationPresented) {
-                Button("search_result.clear_dialog.button.all".localized, role: .destructive) {
-                    recentSearchTexts.removeAll()
-                }
-            } message: {
-                Text("search_result.clear_dialog.description".localized)
             }
         }
     }


### PR DESCRIPTION
Fixes: #954 

It seems to be an issue with SwiftUI itself, therefore the quickest fix we can do is not to have this confirmation dialog, but clearing the search history directly.
