### PR TITLE
798 change url scheme from kiwix to zim

### DIFF
--- a/App/App_iOS.swift
+++ b/App/App_iOS.swift
@@ -29,6 +29,13 @@ struct Kiwix: App {
     init() {
         fileMonitor = DirectoryMonitor(url: URL.documentDirectory) { LibraryOperations.scanDirectory($0) }
         UNUserNotificationCenter.current().delegate = appDelegate
+        // MARK: - migrations
+        if !ProcessInfo.processInfo.arguments.contains("testing") {
+            let migrations = MigrationService(migrations: [
+                Migrations.schemeToZIM(using: Database.shared.viewContext)
+            ])
+            _ = migrations.migrateAll()
+        }
     }
 
     var body: some Scene {
@@ -59,7 +66,7 @@ struct Kiwix: App {
                 .onOpenURL { url in
                     if url.isFileURL {
                         NotificationCenter.openFiles([url], context: .file)
-                    } else if url.isKiwixURL {
+                    } else if url.isZIMURL {
                         NotificationCenter.openURL(url)
                     }
                 }

--- a/App/App_iOS.swift
+++ b/App/App_iOS.swift
@@ -31,10 +31,7 @@ struct Kiwix: App {
         UNUserNotificationCenter.current().delegate = appDelegate
         // MARK: - migrations
         if !ProcessInfo.processInfo.arguments.contains("testing") {
-            let migrations = MigrationService(migrations: [
-                Migrations.schemeToZIM(using: Database.shared.viewContext)
-            ])
-            _ = migrations.migrateAll()
+            _ = MigrationService().migrateAll()
         }
     }
 

--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -168,7 +168,7 @@ struct RootView: View {
         .onOpenURL { url in
             if url.isFileURL {
                 NotificationCenter.openFiles([url], context: .file)
-            } else if url.isKiwixURL {
+            } else if url.isZIMURL {
                 NotificationCenter.openURL(url)
             }
         }
@@ -227,6 +227,13 @@ struct RootView: View {
                     ZimMigration.forCustomApps()
                     navigation.currentItem = .reading
                 }
+            }
+            // MARK: - migrations
+            if !ProcessInfo.processInfo.arguments.contains("testing") {
+                let migrations = MigrationService(migrations: [
+                    Migrations.schemeToZIM(using: Database.shared.viewContext)
+                ])
+                _ = migrations.migrateAll()
             }
         }
         .withHostingWindow { [windowTracker] hostWindow in

--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -230,10 +230,7 @@ struct RootView: View {
             }
             // MARK: - migrations
             if !ProcessInfo.processInfo.arguments.contains("testing") {
-                let migrations = MigrationService(migrations: [
-                    Migrations.schemeToZIM(using: Database.shared.viewContext)
-                ])
-                _ = migrations.migrateAll()
+                _ = MigrationService().migrateAll()
             }
         }
         .withHostingWindow { [windowTracker] hostWindow in

--- a/Model/Entities/SearchResult.m
+++ b/Model/Entities/SearchResult.m
@@ -27,7 +27,7 @@
         if (![path hasPrefix:@"/"]) { path = [@"/" stringByAppendingString:path]; }
         
         NSURLComponents *components = [[NSURLComponents alloc] init];
-        components.scheme = @"kiwix";
+        components.scheme = @"zim";
         components.host = [zimFileID UUIDString];
         components.path = path;
         self.url = [components URL];

--- a/Model/Migration/MigrateSchemeToZIM.swift
+++ b/Model/Migration/MigrateSchemeToZIM.swift
@@ -16,8 +16,7 @@
 import Foundation
 import CoreData
 
-enum Migrations {
-
+extension Migrations {
     /// Change the bookmarks articleURLs from "kiwix://..." to "zim://..."
     /// - Parameter context: DataBase context
     /// - Returns: Migration - general struct

--- a/Model/Migration/MigrateSchemeToZIM.swift
+++ b/Model/Migration/MigrateSchemeToZIM.swift
@@ -1,0 +1,39 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+import CoreData
+
+enum Migrations {
+
+    /// Change the bookmarks articleURLs from "kiwix://..." to "zim://..."
+    /// - Parameter context: DataBase context
+    /// - Returns: Migration - general struct
+    static func schemeToZIM(using context: NSManagedObjectContext) -> Migration {
+        Migration(userDefaultsKey: "migrate_scheme_to_zim") {
+            // bookmarks:
+            let bookmarkPredicate = NSPredicate(format: "articleURL BEGINSWITH[cd] %@", "kiwix://")
+            let bookmarkRequest = Bookmark.fetchRequest(predicate: bookmarkPredicate)
+            let bookmarks: [Bookmark] = (try? context.fetch(bookmarkRequest)) ?? []
+            for bookmark in bookmarks {
+                bookmark.articleURL = bookmark.articleURL.updatedToZIMSheme()
+            }
+            if context.hasChanges {
+                try? context.save()
+            }
+            return true
+        }
+    }
+}

--- a/Model/Migration/MigrationService.swift
+++ b/Model/Migration/MigrationService.swift
@@ -39,6 +39,10 @@ struct Migration {
 struct MigrationService {
     let migrations: [Migration]
 
+    init(migrations: [Migration] = Migrations.all) {
+        self.migrations = migrations
+    }
+
     func migrateAll(using userDefaults: UserDefaulting = UserDefaults.standard) -> Bool {
         var allSucceeded = true
         for migration in migrations where migration.migrate(userDefaults) == false {

--- a/Model/Migration/Migrations.swift
+++ b/Model/Migration/Migrations.swift
@@ -1,0 +1,25 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+
+enum Migrations {
+    
+    /// A central place for all migrations
+    /// they will be executed in the order specified here
+    static let all: [Migration] = [
+        Self.schemeToZIM(using: Database.shared.viewContext)
+    ]
+}

--- a/Model/Utilities/WebKitHandler.swift
+++ b/Model/Utilities/WebKitHandler.swift
@@ -28,7 +28,7 @@ enum RangeRequestError: Error {
 /// To mitigate, opting for the less "broken" behavior of ignoring Range header
 /// until WebKit behavior is changed.
 final class KiwixURLSchemeHandler: NSObject, WKURLSchemeHandler {
-    static let KiwixScheme = "kiwix"
+    static let ZIMScheme = "zim"
     @MainActor private var startedTasks: [Int: Bool] = [:]
 
     // MARK: Life cycle
@@ -75,7 +75,7 @@ final class KiwixURLSchemeHandler: NSObject, WKURLSchemeHandler {
     @MainActor
     private func handle(task urlSchemeTask: WKURLSchemeTask) async {
         let request = urlSchemeTask.request
-        guard let url = request.url, url.isKiwixURL else {
+        guard let url = request.url?.updatedToZIMSheme(), url.isZIMURL else {
             urlSchemeTask.didFailWithError(URLError(.unsupportedURL))
             stopFor(urlSchemeTask.hash)
             return

--- a/Support/Info.plist
+++ b/Support/Info.plist
@@ -28,7 +28,7 @@
 			<string>Viewer</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>kiwix</string>
+				<string>zim</string>
 			</array>
 		</dict>
 	</array>

--- a/Tests/BookmarkMigrationTests.swift
+++ b/Tests/BookmarkMigrationTests.swift
@@ -42,4 +42,9 @@ final class BookmarkMigrationTests: XCTestCase {
         let expectedString = "\0\0\0\u{02}bplist00�\u{01}\u{02}\u{03}\u{04}\u{05}\u{06}^RenderTreeSize^IsAppInitiated^SessionHistory\u{10}\u{03}\t�\u{07}\u{08}\t\n\u{1C}\u{1C}_\u{10}\u{15}SessionHistoryEntries_\u{10}\u{1A}SessionHistoryCurrentIndex_\u{10}\u{15}SessionHistoryVersion�\u{0B}\u{16}�\u{0C}\r\u{0E}\u{0F}\u{10}\u{11}\u{12}\u{13}\u{14}\u{15}_\u{10}\u{17}SessionHistoryEntryData_\u{10}\u{18}SessionHistoryEntryTitle_\u{10}2SessionHistoryEntryShouldOpenExternalURLsPolicyKey_\u{10}\u{16}SessionHistoryEntryURL_\u{10}\u{1E}SessionHistoryEntryOriginalURLO\u{10}P\0\0\0\0\0\0\0\0\u{02}\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0�\u{07}�@�\u{13}\u{06}\0\0\0\0\0\0\0\0\0����\0\0\0\0�\u{07}�@�\u{13}\u{06}\0����\0\0\0\0�\u{03}\0\0\0\0�?\0\0\0\0����TDWDS\u{10}\u{01}_\u{10}2kiwix://A992BF76-CA94-6B60-A762-9B5BC89B5BBF/index_\u{10}2kiwix://A992BF76-CA94-6B60-A762-9B5BC89B5BBF/index�\u{0C}\r\u{0E}\u{0F}\u{10}\u{17}\u{18}\u{19}\u{1A}\u{1B}O\u{10}P\0\0\0\0\0\0\0\0\u{02}\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0V<�A�\u{13}\u{06}\0\0\0\0\0\0\0\0\0����\0\0\0\0U<�A�\u{13}\u{06}\0����\0\0\0\0\0\0\0\0\0\0�?\0\0\0\0����[hier und da\u{10}\u{02}_\u{10}<kiwix://A992BF76-CA94-6B60-A762-9B5BC89B5BBF/wb/hie_.und_.da_\u{10}<kiwix://A992BF76-CA94-6B60-A762-9B5BC89B5BBF/wb/hie_.und_.da\u{10}\u{01}\0\u{08}\0\u{0F}\0\u{1E}\0-\0<\0>\0?\0F\0^\0{\0�\0�\0�\0�\0�\u{01}\u{0B}\u{01}$\u{01}E\u{01}�\u{01}�\u{01}�\u{01}�\u{02}\t\u{02}\u{14}\u{02}g\u{02}s\u{02}u\u{02}�\u{02}�\0\0\0\0\0\0\u{02}\u{01}\0\0\0\0\0\0\0\u{1D}\0\0\0\0\0\0\0\0\0\0\0\0\0\0\u{02}�"
         XCTAssertEqual(outString, expectedString)
     }
+
+    func test_scheme_change() {
+        let url = URL(string: "kiwix://64C3EA1A-5161-2B94-1F50-606DA5EC0035/wb/Saftladen")!
+        XCTAssertEqual(url.updateScheme(to: "zim"), URL(string: "zim://64C3EA1A-5161-2B94-1F50-606DA5EC0035/wb/Saftladen")!)
+    }
 }

--- a/Tests/BookmarkMigrationTests.swift
+++ b/Tests/BookmarkMigrationTests.swift
@@ -45,6 +45,6 @@ final class BookmarkMigrationTests: XCTestCase {
 
     func test_scheme_change() {
         let url = URL(string: "kiwix://64C3EA1A-5161-2B94-1F50-606DA5EC0035/wb/Saftladen")!
-        XCTAssertEqual(url.updateScheme(to: "zim"), URL(string: "zim://64C3EA1A-5161-2B94-1F50-606DA5EC0035/wb/Saftladen")!)
+        XCTAssertEqual(url.updatedToZIMSheme(), URL(string: "zim://64C3EA1A-5161-2B94-1F50-606DA5EC0035/wb/Saftladen")!)
     }
 }

--- a/Tests/URLContentPathTests.swift
+++ b/Tests/URLContentPathTests.swift
@@ -21,6 +21,7 @@ final class URLContentPathTests: XCTestCase {
     private let testURLs = [
         URL(string: "zim://6E4F3D4A-2F8A-789A-3B88-212219F4FB27/irp.fas.org/doddir/milmed/index.html")!,
         URL(string: "zim://861C031F-DAFB-9688-4DB4-8F1199FE2926/mesquartierschinois.wordpress.com/")!,
+        // swiftlint:disable:next line_length
         URL(string: "zim://861C031F-DAFB-9688-4DB4-8F1199FE2926/widgets.wp.com/likes/master.html%3Fver%3D20240530#ver=20240530&lang=fr&lang_ver=1713167421&origin=https://mesquartierschinois.wordpress.com")!
     ]
 

--- a/Tests/URLContentPathTests.swift
+++ b/Tests/URLContentPathTests.swift
@@ -19,9 +19,9 @@ import XCTest
 final class URLContentPathTests: XCTestCase {
 
     private let testURLs = [
-        URL(string: "kiwix://6E4F3D4A-2F8A-789A-3B88-212219F4FB27/irp.fas.org/doddir/milmed/index.html")!,
-        URL(string: "kiwix://861C031F-DAFB-9688-4DB4-8F1199FE2926/mesquartierschinois.wordpress.com/")!,
-        URL(string: "kiwix://861C031F-DAFB-9688-4DB4-8F1199FE2926/widgets.wp.com/likes/master.html%3Fver%3D20240530#ver=20240530&lang=fr&lang_ver=1713167421&origin=https://mesquartierschinois.wordpress.com")!
+        URL(string: "zim://6E4F3D4A-2F8A-789A-3B88-212219F4FB27/irp.fas.org/doddir/milmed/index.html")!,
+        URL(string: "zim://861C031F-DAFB-9688-4DB4-8F1199FE2926/mesquartierschinois.wordpress.com/")!,
+        URL(string: "zim://861C031F-DAFB-9688-4DB4-8F1199FE2926/widgets.wp.com/likes/master.html%3Fver%3D20240530#ver=20240530&lang=fr&lang_ver=1713167421&origin=https://mesquartierschinois.wordpress.com")!
     ]
 
     func test_no_leading_slash() {
@@ -31,7 +31,7 @@ final class URLContentPathTests: XCTestCase {
     }
 
     func test_preserves_trailing_slash() {
-        let url = URL(string: "kiwix://861C031F-DAFB-9688-4DB4-8F1199FE2926/mesquartierschinois.wordpress.com/")!
+        let url = URL(string: "zim://861C031F-DAFB-9688-4DB4-8F1199FE2926/mesquartierschinois.wordpress.com/")!
         XCTAssertEqual(url.contentPath.last, "/")
     }
 

--- a/Views/BuildingBlocks/WebView.swift
+++ b/Views/BuildingBlocks/WebView.swift
@@ -224,7 +224,7 @@ extension WKWebView {
 final class WebViewConfiguration: WKWebViewConfiguration {
     override init() {
         super.init()
-        setURLSchemeHandler(KiwixURLSchemeHandler(), forURLScheme: KiwixURLSchemeHandler.KiwixScheme)
+        setURLSchemeHandler(KiwixURLSchemeHandler(), forURLScheme: KiwixURLSchemeHandler.ZIMScheme)
         #if os(macOS)
         preferences.isElementFullscreenEnabled = true
         #else

--- a/Views/ViewModifiers/SaveContentHandler.swift
+++ b/Views/ViewModifiers/SaveContentHandler.swift
@@ -27,7 +27,7 @@ struct SaveContentHandler: ViewModifier {
     func body(content: Content) -> some View {
         content.onReceive(saveContentToFile) { notification in
             guard let url = notification.userInfo?["url"] as? URL,
-                  url.isKiwixURL else {
+                  url.isZIMURL else {
                 return
             }
             #if os(macOS)


### PR DESCRIPTION
Fixes: #798 

**Note**: changes applied on top of the #956 PR.

## Solution:

### Update the code to create "zim://" urls
Whenever we re-constructing urls (eg. to create bookmarks), the code has been updated.

### Migrating bookmarks:
This was the easy part, once the app starts we do a one-off migration, selecting the bookmarks that start with the url "kiwix://" and update those to be "zim://"

### Migrating tabs:
This was the hard part. We store the tabs together with the so called "interactiveState" of the webView loaded. Which is a serialised data provided by Apple. This contains the loaded url, and the browsing history (eg. former urls).

Formerly we used a "trick" to update such urls, for the [migration of ZIM files](https://github.com/kiwix/kiwix-apple/pull/700/files), which is in short utf8 decode the data, and from that regex replace the urls.

Now the same trick is not working to change the url scheme, possibly because the length of the string is changing. Formerly we updated the zim id of the urls, which is the same length. (The scheme change from "kiwix" to "zim" is not the same length).
**Editing the data as utf8 decoded string (as before), breaks the tabs, and they won’t load.**

This "interactiveState" of the webView is not properly modifiable, or decodable in a reliable fashion, [details of serialisation here](https://github.com/WebKit/WebKit/blob/debb3b092dee3eb99fc49e79423f7a627b72dbff/Source/WebKit/Shared/SessionState.serialization.in).

It seems to be plist file, but cannot be decoded neither with python (``plistlib``), nor with swift (``PropertyListDecoder``), nor with macOS (``plutil``), without the detailed serialisation knowledge, it just won’t work.

**TLDR: For these reasons, it should not be modified directly.**

### Solution for tab urls:
Since the tab urls, and interactive state is "saved" once we leave a tab (or the application), the solution is to migrate those urls "on demand", meaning once we want to load such a URL, we check if it's an old "kiwix" one, and modify it to be a new "zim" url, and load that instead.
Once loaded as a new "zim" URL, it will be saved correctly.


### Possible followup:
Since we have a new DWDS content, in a separate PR, I can remove this "utf-8" decoding "trick" introduced by [this older PR](https://github.com/kiwix/kiwix-apple/pull/700/files), and replace it with a similar "on demand" migration solution to change the hosts (ZIM file id migration from old to new).