### PR TITLE
Fix search snippet color

### DIFF
--- a/SwiftUI/Model/SearchOperation/SearchOperation.swift
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.swift
@@ -14,7 +14,9 @@
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
 import Defaults
-import SwiftUI
+#if os(iOS)
+import UIKit
+#endif
 
 extension SearchOperation {
     var results: [SearchResult] { __results.array as? [SearchResult] ?? [] }
@@ -41,10 +43,14 @@ extension SearchOperation {
                               .characterEncoding: String.Encoding.utf8.rawValue],
                     documentAttributes: nil
                 ) {
+                    #if os(iOS)
                     let stringWithColor = NSMutableAttributedString(attributedString: stringWithoutColor),
                         range = NSRange(location:0, length: stringWithColor.length)
                     stringWithColor.addAttribute(.foregroundColor, value: UIColor.label, range: range)
                     result.snippet = stringWithColor
+                    #else
+                    result.snippet = stringWithoutColor
+                    #endif
                 }
             }
         }

--- a/SwiftUI/Model/SearchOperation/SearchOperation.swift
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.swift
@@ -14,6 +14,7 @@
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
 import Defaults
+import SwiftUI
 
 extension SearchOperation {
     var results: [SearchResult] { __results.array as? [SearchResult] ?? [] }
@@ -33,12 +34,18 @@ extension SearchOperation {
             for result in results {
                 guard let html = result.htmlSnippet,
                       let data = html.data(using: .utf8) else { return }
-                result.snippet = try? NSAttributedString(
+                result.snippet = nil
+                if let stringWithoutColor = try? NSAttributedString(
                     data: data,
                     options: [.documentType: NSAttributedString.DocumentType.html,
                               .characterEncoding: String.Encoding.utf8.rawValue],
                     documentAttributes: nil
-                )
+                ) {
+                    let stringWithColor = NSMutableAttributedString(attributedString: stringWithoutColor),
+                        range = NSRange(location:0, length: stringWithColor.length)
+                    stringWithColor.addAttribute(.foregroundColor, value: UIColor.label, range: range)
+                    result.snippet = stringWithColor
+                }
             }
         }
 


### PR DESCRIPTION
In dark mode, search result snippets are difficult to read because they are displayed in black on a grey background as shown below.

![Simulator Screenshot - iPad Air (4th generation) - 2024-09-03 at 10 28 17](https://github.com/user-attachments/assets/7a1d09e7-01e5-49f5-b67e-e88493207cab)

This happens on iPads and iPhones.
This PR tries to resolve the issue.
