### PR TITLE
Fix opening app with ZIM doesn't open ZIM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.5.2
-
+- FIX:
+  - Opening ZIM file from macOS Finder (@BPerlakiH #968)
 
 ## 3.5.1
 - FIX:

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -70,15 +70,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
     @Published var externalURL: URL?
     private var metaData: URLContentMetaData?
 
-    private(set) var tabID: NSManagedObjectID? {
-        didSet {
-#if os(macOS)
-            if let tabID, tabID != oldValue {
-                storeTabIDInCurrentWindow()
-            }
-#endif
-        }
-    }
+    private(set) var tabID: NSManagedObjectID?
 #if os(macOS)
     private var windowURLs: [URL] {
         UserDefaults.standard[.windowURLs]
@@ -551,71 +543,6 @@ final class BrowserViewModel: NSObject, ObservableObject,
             }
         )
         completionHandler(configuration)
-    }
-#endif
-
-    // MARK: - TabID management via NSWindow for macOS
-
-#if os(macOS)
-    private (set) var windowNumber: Int?
-
-    // RESTORATION
-    func restoreByWindowNumber(
-        windowNumber currentNumber: Int,
-        urlToTabIdConverter: @MainActor @escaping (URL?) -> NSManagedObjectID
-    ) {
-        windowNumber = currentNumber
-        let windows = NSApplication.shared.windows
-        let tabURL: URL?
-
-        guard let currentWindow = windowBy(number: currentNumber),
-              let index = windows.firstIndex(of: currentWindow) else { return }
-
-        // find the url for this window in user defaults, by pure index
-        if 0 <= index,
-           index < windowURLs.count {
-            tabURL = windowURLs[index]
-        } else {
-            tabURL = nil
-        }
-        Task {
-            await MainActor.run {
-                let tabID = urlToTabIdConverter(tabURL) // if url is nil it will create a new tab
-                self.tabID = tabID
-                restoreBy(tabID: tabID)
-            }
-        }
-    }
-
-    private func indexOf(windowNumber number: Int, in windows: [NSWindow]) -> Int? {
-        let windowNumbers = windows.map { $0.windowNumber }
-        guard windowNumbers.contains(number),
-              let index = windowNumbers.firstIndex(of: number) else {
-            return nil
-        }
-        return index
-    }
-
-    // PERSISTENCE:
-    func persistAllTabIdsFromWindows() {
-        let urls = NSApplication.shared.windows.compactMap { window in
-            window.accessibilityURL()
-        }
-        UserDefaults.standard[.windowURLs] = urls
-    }
-
-    private func storeTabIDInCurrentWindow() {
-        guard let tabID,
-              let windowNumber,
-              let currentWindow = windowBy(number: windowNumber) else {
-            return
-        }
-        let url = tabID.uriRepresentation()
-        currentWindow.setAccessibilityURL(url)
-    }
-
-    private func windowBy(number: Int) -> NSWindow? {
-        NSApplication.shared.windows.first { $0.windowNumber == number }
     }
 #endif
 

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -70,7 +70,15 @@ final class BrowserViewModel: NSObject, ObservableObject,
     @Published var externalURL: URL?
     private var metaData: URLContentMetaData?
 
-    private(set) var tabID: NSManagedObjectID?
+    private(set) var tabID: NSManagedObjectID? {
+        didSet {
+#if os(macOS)
+            if let tabID, tabID != oldValue {
+                storeTabIDInCurrentWindow()
+            }
+#endif
+        }
+    }
 #if os(macOS)
     private var windowURLs: [URL] {
         UserDefaults.standard[.windowURLs]
@@ -543,6 +551,64 @@ final class BrowserViewModel: NSObject, ObservableObject,
             }
         )
         completionHandler(configuration)
+    }
+#endif
+
+    // MARK: - TabID management via NSWindow for macOS
+
+#if os(macOS)
+    private (set) var windowNumber: Int?
+
+    // RESTORATION
+    func restoreByWindowNumber(
+        windowNumber currentNumber: Int,
+        urlToTabIdConverter: @MainActor @escaping (URL?) -> NSManagedObjectID
+    ) {
+        windowNumber = currentNumber
+        let windows = NSApplication.shared.windows
+        let tabURL: URL?
+
+        guard let currentWindow = windowBy(number: currentNumber),
+              let index = windows.firstIndex(of: currentWindow) else { return }
+
+        // find the url for this window in user defaults, by pure index
+        if 0 <= index,
+           index < windowURLs.count {
+            tabURL = windowURLs[index]
+        } else {
+            tabURL = nil
+        }
+        Task {
+            await MainActor.run {
+                let tabID = urlToTabIdConverter(tabURL) // if url is nil it will create a new tab
+                self.tabID = tabID
+                restoreBy(tabID: tabID)
+            }
+        }
+    }
+
+    private func indexOf(windowNumber number: Int, in windows: [NSWindow]) -> Int? {
+        let windowNumbers = windows.map { $0.windowNumber }
+        guard windowNumbers.contains(number),
+              let index = windowNumbers.firstIndex(of: number) else {
+            return nil
+        }
+        return index
+    }
+
+    // PERSISTENCE:
+    private func storeTabIDInCurrentWindow() {
+        guard let tabID,
+              let windowNumber,
+              let currentWindow = windowBy(number: windowNumber) else {
+            return
+        }
+        let url = tabID.uriRepresentation()
+        currentWindow.setAccessibilityURL(url)
+    }
+
+    private func windowBy(number: Int) -> NSWindow? {
+        NSApplication.shared.windows.first { $0.windowNumber == number }
     }
 #endif
 


### PR DESCRIPTION
Fixes: #962 

As mentioned in the ticket description, the easiest way to fix this issue is to disable the non-working window restore solution on macOS.

**Testing: Make sure you have only 1 version of Kiwix installed**. It is possible to have  multiple of them (eg from: AppStore, TestFlight, local build).
and as of [Apple docs](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app):

> If multiple apps register the same scheme, the app the system targets is undefined.

meaning that the clicked ZIM file might open in another version of Kiwix, if you have more than 1 installed.

