### PR TITLE
Fix search results snippet and sorting issue

### DIFF
--- a/SwiftUI/Model/SearchOperation/SearchOperation.swift
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.swift
@@ -32,7 +32,7 @@ extension SearchOperation {
         if case .matches = Defaults[.searchResultSnippetMode] {
             for result in results {
                 guard let html = result.htmlSnippet,
-                      let data = html.data(using: .utf8) else { return }
+                      let data = html.data(using: .utf8) else { continue }
                 result.snippet = try? NSAttributedString(
                     data: data,
                     options: [.documentType: NSAttributedString.DocumentType.html,


### PR DESCRIPTION
If one of search results does not have a snippet, the following issues seem to occur:

- subsequent snippets are ignored
- results are not sorted.

This is caused by an early return from search function.
This PR tries to fix the issue.