### PR TITLE
Remove duplicate entry from search results

### DIFF
--- a/Model/Entities/SearchResult.h
+++ b/Model/Entities/SearchResult.h
@@ -24,6 +24,7 @@
 @property (nonatomic, strong, nullable) NSAttributedString *snippet;
 @property (nonatomic, strong, nullable) NSNumber *probability;
 @property (nonatomic, strong, nullable) NSNumber *score;
+@property (nonatomic, assign) uint32_t index;   // zim::entry_index_type
 
 - (nullable instancetype)initWithZimFileID:(nonnull NSUUID *)zimFileID
                                       path:(nonnull NSString *)path


### PR DESCRIPTION
The search results sometimes contain two identical entries, one with the snippet and another without it.
This is because index search results and title search results are treated separately.
This PR attempts to remove the duplicate results.