### PR TITLE
Remove duplicate search entries

### DIFF
--- a/SwiftUI/Model/SearchOperation/SearchOperation.h
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) NSString *searchText;
 @property (nonatomic, assign) BOOL extractMatchingSnippet;
-
+@property (nonatomic, strong) NSMutableSet *foundURLs;
 @property (nonatomic, strong) NSMutableOrderedSet *results NS_REFINED_FOR_SWIFT;
 
 - (id)initWithSearchText:(NSString *)searchText zimFileIDs:(NSSet *)zimFileIDs;

--- a/SwiftUI/Model/SearchOperation/SearchOperation.mm
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.mm
@@ -76,10 +76,10 @@
         std::string zimFileID_C = [[[zimFileID UUIDString] lowercaseString] cStringUsingEncoding:NSUTF8StringEncoding];
         try {
             auto archive = allArchives->at(zimFileID_C);
-            [self addTitleSearchResults:archive count: 25];
             if (archive.hasFulltextIndex()) {
                 [self addIndexSearchResults:archive count: 25];
             }
+            [self addTitleSearchResults:archive count: 25];
         } catch (std::exception &e) {
             NSLog(@"perform search exception: %s", e.what());
         }

--- a/SwiftUI/Model/SearchOperation/SearchOperation.mm
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.mm
@@ -72,74 +72,70 @@
     typedef std::unordered_map<std::string, zim::Archive> archives_map;
     auto *allArchives = static_cast<archives_map *>([[ZimFileService sharedInstance] getArchives]);
 
-    std::vector<zim::Archive> indexSearchArchives = std::vector<zim::Archive>();
-    std::vector<zim::Archive> titleSearchArchives = std::vector<zim::Archive>();
     for (NSUUID *zimFileID in self.zimFileIDs) {
         std::string zimFileID_C = [[[zimFileID UUIDString] lowercaseString] cStringUsingEncoding:NSUTF8StringEncoding];
         try {
             auto archive = allArchives->at(zimFileID_C);
+            [self addTitleSearchResults:archive count: 25];
             if (archive.hasFulltextIndex()) {
-                indexSearchArchives.push_back(archive);
+                [self addIndexSearchResults:archive count: 25];
             }
-            titleSearchArchives.push_back(archive);
-        } catch (std::exception) { }
-    }
-
-    // perform index and title search
-    try {
-        [self addIndexSearchResults:indexSearchArchives];
-    } catch (std::exception) { }
-    if (titleSearchArchives.size() > 0) {
-        int count = std::max((35 - (int)[self.results count]) / (int)titleSearchArchives.size(), 5);
-        [self addTitleSearchResults:titleSearchArchives count:(int)count];
+        } catch (std::exception &e) {
+            NSLog(@"perform search exception: %s", e.what());
+        }
     }
 }
 
 /// Add search results based on search index.
-/// @param archives archives to retrieve search results from
-- (void)addIndexSearchResults:(std::vector<zim::Archive>)archives {
+/// @param archive to retrieve search results from
+/// @param count number of articles to retrieve
+- (void)addIndexSearchResults:(zim::Archive)archive count:(int)count {
     // initialize and start full text search
     if (self.isCancelled) { return; }
-    if (archives.empty()) { return; }
-    zim::Searcher searcher = zim::Searcher(archives);
-    zim::SearchResultSet resultSet = searcher.search(zim::Query(self.searchText_C)).getResults(0, 25);
-    
-    // retrieve full text search results
-    for (auto result = resultSet.begin(); result != resultSet.end(); result++) {
-        if (self.isCancelled) { break; }
-        
-        zim::Item item = result->getItem(result->isRedirect());
-        NSUUID *zimFileID = [[NSUUID alloc] initWithUUIDBytes:(unsigned char *)result.getZimId().data];
-        NSString *path = [NSString stringWithCString:item.getPath().c_str() encoding:NSUTF8StringEncoding];
-        NSString *title = [NSString stringWithCString:item.getTitle().c_str() encoding:NSUTF8StringEncoding];
-        if (title.length == 0) {
-            title = path; // display the path as a fallback
+    try {
+        std::vector<zim::Archive> archives = std::vector<zim::Archive>();
+        archives.push_back(archive);
+        zim::Searcher searcher = zim::Searcher(archives);
+        zim::SearchResultSet resultSet = searcher.search(zim::Query(self.searchText_C)).getResults(0, count);
+
+        // retrieve full text search results
+        for (auto result = resultSet.begin(); result != resultSet.end(); result++) {
+            if (self.isCancelled) { break; }
+
+            zim::Item item = result->getItem(result->isRedirect());
+            NSUUID *zimFileID = [[NSUUID alloc] initWithUUIDBytes:(unsigned char *)result.getZimId().data];
+            NSString *path = [NSString stringWithCString:item.getPath().c_str() encoding:NSUTF8StringEncoding];
+            NSString *title = [NSString stringWithCString:item.getTitle().c_str() encoding:NSUTF8StringEncoding];
+            if (title.length == 0) {
+                title = path; // display the path as a fallback
+            }
+            SearchResult *searchResult = [[SearchResult alloc] initWithZimFileID:zimFileID path:path title:title];
+            searchResult.probability = [[NSNumber alloc] initWithFloat:result.getScore() / 100];
+
+            // optionally, add snippet
+            if (self.extractMatchingSnippet) {
+                NSString *html = [NSString stringWithCString:result.getSnippet().c_str() encoding:NSUTF8StringEncoding];
+                searchResult.htmlSnippet = html;
+            }
+            if (searchResult != nil) {
+                [self addResult: searchResult];
+            }
         }
-        SearchResult *searchResult = [[SearchResult alloc] initWithZimFileID:zimFileID path:path title:title];
-        searchResult.probability = [[NSNumber alloc] initWithFloat:result.getScore() / 100];
-        
-        // optionally, add snippet
-        if (self.extractMatchingSnippet) {
-            NSString *html = [NSString stringWithCString:result.getSnippet().c_str() encoding:NSUTF8StringEncoding];
-            searchResult.htmlSnippet = html;
-        }
-        if (searchResult != nil) {
-            [self addResult: searchResult];
-        }
+    } catch (std::exception &e) {
+        NSLog(@"index search error: %s", e.what());
     }
 }
 
 /// Add search results based on matching article titles with search text.
-/// @param archives archives to retrieve search results from
-/// @param count number of articles to retrieve for each archive
-- (void)addTitleSearchResults:(std::vector<zim::Archive>)archives count:(int)count {
-    for (zim::Archive archive: archives) {
-        if (self.isCancelled) { break; }
-        
+/// @param archive to retrieve search results from
+/// @param count number of articles to retrieve
+- (void)addTitleSearchResults:(zim::Archive) archive count:(int)count {
+    if (self.isCancelled) { return; }
+    try {
         NSUUID *zimFileID = [[NSUUID alloc] initWithUUIDBytes:(unsigned char *)archive.getUuid().data];
         auto results = zim::SuggestionSearcher(archive).suggest(self.searchText_C).getResults(0, count);
         for (auto result = results.begin(); result != results.end(); result++) {
-            if (self.isCancelled) { break; }
+            if (self.isCancelled) { return; }
             NSString *path = [NSString stringWithCString:result->getPath().c_str() encoding:NSUTF8StringEncoding];
             NSString *title = [NSString stringWithCString:result->getTitle().c_str() encoding:NSUTF8StringEncoding];
             if (title.length > 0) {
@@ -149,6 +145,8 @@
                 }
             }
         }
+    } catch (std::exception &e) {
+        NSLog(@"title search error: %s", e.what());
     }
 }
 


### PR DESCRIPTION
Fixes: #980 
Superseeds #979

What we really want is unique search results, which is in fact unique URLs that the user can click on and navigate further. If 2 search results are linking to the same URL, that's a duplicate.

## Solution
Store a set of ``foundURLs`` as we are processing the search results (both indexed and title search), and look for duplicates. Also make sure we adjust the URL endings to always contain the trailing "/" slash, but this is only for our comparison, the returned search result URLs should not be modified.

## After the fix on macOS:

<img width="1552" alt="Screenshot 2024-09-15 at 13 47 36" src="https://github.com/user-attachments/assets/9917f6c6-b0cf-4524-a110-62165dc1c91b">
