### PR TITLE
Fix video only on active scene

### DIFF
--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -17,6 +17,7 @@ import SwiftUI
 
 /// This is macOS and iPad only specific, not used on iPhone
 struct BrowserTab: View {
+    @Environment(\.scenePhase) private var scenePhase
     @EnvironmentObject private var browser: BrowserViewModel
     @StateObject private var search = SearchViewModel()
 
@@ -55,6 +56,11 @@ struct BrowserTab: View {
         .focusedSceneValue(\.canGoForward, browser.canGoForward)
         .modifier(ExternalLinkHandler(externalURL: $browser.externalURL))
         .searchable(text: $search.searchText, placement: .toolbar, prompt: "common.search".localized)
+        .onChange(of: scenePhase) { newValue in
+            if case .active = newValue {
+                browser.refreshVideoState()
+            }
+        }
         .modify { view in
             #if os(macOS)
             view.navigationTitle(browser.articleTitle.isEmpty ? Brand.appName : browser.articleTitle)
@@ -65,7 +71,6 @@ struct BrowserTab: View {
         }
         .onAppear {
             browser.updateLastOpened()
-            browser.refreshVideoState()
         }
         .onDisappear {
             browser.pauseVideoWhenNotInPIP()


### PR DESCRIPTION
Fixes: #978 

For some unknown reasons, SwiftUI is triggering the (formerly used) ``.onAppear`` callback even if the application is in the background.

Changing that to observing, when the application becomes ``active``, solves this issue.

I have tested it with the video in the ticket both on iPad 17, and macOS.
iPhone testing was omitted, as the changed file is not used there.