### PR TITLE
Remove OrderedCollections dependency

### DIFF
--- a/Tests/OrderedCacheTests.swift
+++ b/Tests/OrderedCacheTests.swift
@@ -1,0 +1,63 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import XCTest
+@testable import Kiwix
+
+final class OrderedCacheTests: XCTestCase {
+
+    @MainActor
+    func testEmpty() {
+        let cache = OrderedCache<String, String>()
+        XCTAssertEqual(cache.count, 0)
+        XCTAssertNil(cache.findBy(key: "not to be found"))
+    }
+
+    @MainActor
+    func testOneItem() {
+        let cache = OrderedCache<String, String>()
+        let pastDate = Date.distantPast
+        cache.setValue("test_value", forKey: "keyOne", dated: pastDate)
+        XCTAssertEqual(cache.count, 1)
+        XCTAssertNil(cache.findBy(key: "not to be found"))
+        XCTAssertEqual(cache.findBy(key: "keyOne"), "test_value")
+        cache.removeOlderThan(pastDate)
+        XCTAssertEqual(cache.count, 1)
+        cache.removeOlderThan(Date.now)
+        XCTAssertEqual(cache.count, 0)
+    }
+
+    @MainActor
+    func testRemoveOlderThan() {
+        let cache = OrderedCache<String, String>()
+        let nowDate = Date.now
+        cache.setValue("test_value", forKey: "keyOne", dated: nowDate)
+        cache.setValue("old_value", forKey: "keyOld", dated: Date.distantPast)
+        XCTAssertEqual(cache.count, 2)
+        cache.removeOlderThan(nowDate.advanced(by: -1))
+        XCTAssertEqual(cache.count, 1)
+    }
+
+    @MainActor
+    func testRemoveByKey() {
+        let cache = OrderedCache<String, Int>()
+        cache.setValue(1, forKey: "one")
+        cache.setValue(0, forKey: "zero")
+        cache.removeValue(forKey: "zero")
+        XCTAssertNil(cache.findBy(key: "zero"))
+        XCTAssertEqual(cache.findBy(key: "one"), 1)
+    }
+
+}

--- a/ViewModel/OrderedCache.swift
+++ b/ViewModel/OrderedCache.swift
@@ -1,0 +1,56 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+
+@MainActor
+final class OrderedCache<Key: Hashable, Value>  {
+
+    private struct ValueDated<V> {
+        let value: V
+        let date: Date
+    }
+
+    private var dict: [Key: ValueDated<Value>] = [:]
+
+    var count: Int {
+        dict.count
+    }
+
+    func findBy(key: Key) -> Value? {
+        if let dateValue = dict[key] {
+            return dateValue.value
+        }
+        return nil
+    }
+
+    func removeAll() {
+        dict = [:]
+    }
+
+    func removeOlderThan(_ pastDate: Date) {
+        dict = dict.filter { (key: Key, value: ValueDated<Value>) in
+            value.date >= pastDate
+        }
+    }
+
+    func setValue(_ value: Value, forKey key: Key, dated: Date = Date.now) {
+        dict[key] = ValueDated(value: value, date: dated)
+    }
+
+    func removeValue(forKey key: Key) {
+        dict.removeValue(forKey: key)
+    }
+}

--- a/ViewModel/OrderedCache.swift
+++ b/ViewModel/OrderedCache.swift
@@ -16,7 +16,7 @@
 import Foundation
 
 @MainActor
-final class OrderedCache<Key: Hashable, Value>  {
+final class OrderedCache<Key: Hashable, Value> {
 
     private struct ValueDated<V> {
         let value: V
@@ -41,7 +41,7 @@ final class OrderedCache<Key: Hashable, Value>  {
     }
 
     func removeOlderThan(_ pastDate: Date) {
-        dict = dict.filter { (key: Key, value: ValueDated<Value>) in
+        dict = dict.filter { (_, value: ValueDated<Value>) in
             value.date >= pastDate
         }
     }

--- a/project.yml
+++ b/project.yml
@@ -48,9 +48,6 @@ packages:
   Defaults:
     url: https://github.com/sindresorhus/Defaults
     majorVersion: 6.0.0
-  OrderedCollections:
-    url: https://github.com/apple/swift-collections.git
-    majorVersion: 1.0.4
 
 targetTemplates:
   ApplicationTemplate:
@@ -73,7 +70,6 @@ targetTemplates:
       - sdk: NotificationCenter.framework
       - sdk: QuickLook.framework
       - package: Defaults
-      - package: OrderedCollections
     sources: 
       - path: App
       - path: Model


### PR DESCRIPTION
Fixes: #988 

One of our dependencies is OrderedCollections, which is a large amount of extension from Apple, out of that we only use 1 file, and not even to it's full extent, as the most interesting part of it is used, when we run out of memory, and try to remove the "older" entries from the cache.

Proposition: instead of using a whole library, just do a simple class that does the same work.