### PR TITLE
corrected name of config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip install -e .
 
-kiwix-build --target-platform apple_all_static libkiwix
+kiwix-build --config apple_all_static libkiwix
 # assuming your kiwix-build and apple folder at at same level
 cp -r BUILD_apple_all_static/INSTALL/lib/CoreKiwix.xcframework ../apple/
 ```


### PR DESCRIPTION
The installation instruction listed the wrong installation command. I updated it to reflect the correct flag name, which is correctly listed in the kiwix-build repository, but for some reason was listed differently here.