### PR TITLE
Avoid crash on iOS 18

### DIFF
--- a/Views/BuildingBlocks/WebView.swift
+++ b/Views/BuildingBlocks/WebView.swift
@@ -122,7 +122,9 @@ final class WebViewController: UIViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        webView.setValue(view.safeAreaInsets, forKey: "_obscuredInsets")
+        if #unavailable(iOS 18.0) {
+            webView.setValue(view.safeAreaInsets, forKey: "_obscuredInsets")
+        }
         layoutSubject.send()
     }
 }


### PR DESCRIPTION
Related to: #993 

On iPad 18.1 the following webView function is deprecated, and leads to a crash:
<img width="1038" alt="Screenshot 2024-10-05 at 21 25 58" src="https://github.com/user-attachments/assets/d6f80eb8-f16a-497a-9088-99211cfae545">

Whereas deleting the book does work on 18.1 (simulator):

https://github.com/user-attachments/assets/bdd5f1a3-c8c5-4604-b7d6-3c5104b73d3b



and it seems that unlinking the book also works on 18.1 (simulator):

https://github.com/user-attachments/assets/690a6112-e375-4880-97c8-5e0f1f8d75ac



Will test on device as well..