### PR TITLE
Improve launch sequence for custom apps

### DIFF
--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -127,7 +127,7 @@ struct RootView: View {
         } detail: {
             switch navigation.currentItem {
             case .loading:
-                LoadingView()
+                LoadingDataView()
             case .reading:
                 BrowserTab().environmentObject(browser)
                     .withHostingWindow { window in

--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -240,9 +240,9 @@ private struct Content<LaunchModel>: View where LaunchModel: LaunchProtocol {
 
     var body: some View {
         Group {
+            // swiftlint:disable:next redundant_discardable_let
             let _ = model.updateWith(hasZimFiles: !zimFiles.isEmpty,
                                      hasSeenCategories: hasSeenCategories)
-            let _ = debugPrint("model.state: \(model.state)")
             switch model.state {
             case .loadingData:
                 LoadingDataView()

--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -154,6 +154,14 @@ private struct CompactView: View {
             LoadingView()
         } else if case let .tab(tabID) = navigation.currentItem {
             let browser = BrowserViewModel.getCached(tabID: tabID)
+            let model = if FeatureFlags.hasLibrary {
+                CatalogLaunchViewModel(library: library,
+                                       browser: browser,
+                                       hasSeenCategories: Defaults.publisher(.hasSeenCategories)
+                )
+            } else {
+                NoCatalogLaunchViewModel(browser: browser)
+            }
             Content(tabID: tabID, showLibrary: {
                 if presentedSheet == nil {
                     presentedSheet = .library
@@ -161,7 +169,7 @@ private struct CompactView: View {
                     // there's a sheet already presented by the user
                     // do nothing
                 }
-            }, model: FeatureFlags.hasLibrary ? CatalogLaunchViewModel(library: library, browser: browser) : NoCatalogLaunchViewModel(browser: browser) )
+            }, model: model)
                 .id(tabID)
                 .toolbar {
                     ToolbarItemGroup(placement: .bottomBar) {
@@ -236,15 +244,6 @@ private struct Content<LaunchModel>: View where LaunchModel: LaunchProtocol {
         Group {
             let _ = model.updateWith(hasZimFiles: !zimFiles.isEmpty)
             let _ = debugPrint("model.state: \(model.state)")
-//            switch model.state {
-//
-//                case .loadingData:
-//                    Text("Loading data...")
-//                case .catalog(.list):
-//                    Text("Catalog list")
-//                default:
-//                    Text("")
-//            }
             if browser.url == nil || (!FeatureFlags.hasLibrary && isInitialLoad) {
                 Welcome(showLibrary: showLibrary)
             } else {

--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -228,8 +228,6 @@ private struct Content<LaunchModel>: View where LaunchModel: LaunchProtocol {
         sortDescriptors: [NSSortDescriptor(keyPath: \ZimFile.size, ascending: false)],
         predicate: ZimFile.openedPredicate
     ) private var zimFiles: FetchedResults<ZimFile>
-    @State var isInitialLoad: Bool = true
-    
     /// this is still hacky a bit, as the change from here re-validates the view
     /// which triggers the model to be revalidated
     @Default(.hasSeenCategories) private var hasSeenCategories
@@ -298,11 +296,6 @@ private struct Content<LaunchModel>: View where LaunchModel: LaunchProtocol {
         .onChange(of: scenePhase) { newValue in
             if case .active = newValue {
                 browser.refreshVideoState()
-            }
-        }
-        .onChange(of: browser.isLoading) { isLoading in
-            if isLoading == false { // wait for the first full webpage load
-                isInitialLoad = false
             }
         }
     }

--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -155,10 +155,7 @@ private struct CompactView: View {
         } else if case let .tab(tabID) = navigation.currentItem {
             let browser = BrowserViewModel.getCached(tabID: tabID)
             let model = if FeatureFlags.hasLibrary {
-                CatalogLaunchViewModel(library: library,
-                                       browser: browser,
-                                       hasSeenCategories: Defaults.publisher(.hasSeenCategories)
-                )
+                CatalogLaunchViewModel(library: library, browser: browser)
             } else {
                 NoCatalogLaunchViewModel(browser: browser)
             }
@@ -242,7 +239,8 @@ private struct Content<LaunchModel>: View where LaunchModel: LaunchProtocol {
 
     var body: some View {
         Group {
-            let _ = model.updateWith(hasZimFiles: !zimFiles.isEmpty)
+            let _ = model.updateWith(hasZimFiles: !zimFiles.isEmpty,
+                                     hasSeenCategories: hasSeenCategories)
             let _ = debugPrint("model.state: \(model.state)")
             if browser.url == nil || (!FeatureFlags.hasLibrary && isInitialLoad) {
                 Welcome(showLibrary: showLibrary)

--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -304,6 +304,7 @@ private struct Content<LaunchModel>: View where LaunchModel: LaunchProtocol {
     }
 
     private func showTheLibrary() {
+        guard model.state.shouldShowCatalog else { return }
         #if os(macOS)
         navigation.currentItem = .categories
         #else

--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -22,6 +22,7 @@ import Combine
 import SwiftUI
 import UIKit
 import CoreData
+import Defaults
 
 final class CompactViewController: UIHostingController<AnyView>, UISearchControllerDelegate, UISearchResultsUpdating {
     private let searchViewModel: SearchViewModel
@@ -223,6 +224,10 @@ private struct Content<LaunchModel>: View where LaunchModel: LaunchProtocol {
         predicate: ZimFile.openedPredicate
     ) private var zimFiles: FetchedResults<ZimFile>
     @State var isInitialLoad: Bool = true
+    
+    /// this is still hacky a bit, as the change from here re-validates the view
+    /// which triggers the model to be revalidated
+    @Default(.hasSeenCategories) private var hasSeenCategories
     let tabID: NSManagedObjectID?
     let showLibrary: () -> Void
     @ObservedObject var model: LaunchModel

--- a/App/SplitViewController.swift
+++ b/App/SplitViewController.swift
@@ -141,7 +141,7 @@ final class SplitViewController: UISplitViewController {
             let controller = UIHostingController(rootView: Settings())
             setViewController(UINavigationController(rootViewController: controller), for: .secondary)
         case .loading:
-            let controller = UIHostingController(rootView: LoadingView())
+            let controller = UIHostingController(rootView: LoadingDataView())
             setViewController(UINavigationController(rootViewController: controller), for: .secondary)
         default:
             let controller = UIHostingController(rootView: Text("vc-not-implemented"))

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -165,7 +165,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
         }
 
         isLoadingObserver = webView.observe(\.isLoading, options: .new) { [weak self] _, change in
-            Task { @MainActor in
+            Task { @MainActor [weak self] in
                 if change.newValue != self?.isLoading {
                     self?.isLoading = change.newValue
                 }

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -100,6 +100,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
 
     // MARK: - Lifecycle
 
+    // swiftlint:disable:next function_body_length
     @MainActor
     init(tabID: NSManagedObjectID? = nil) {
         self.tabID = tabID
@@ -164,7 +165,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
             self?.didUpdate(title: title, url: url)
         }
 
-        isLoadingObserver = webView.observe(\.isLoading, options: .new) { [weak self] webView, change in
+        isLoadingObserver = webView.observe(\.isLoading, options: .new) { [weak self] _, change in
             Task { @MainActor in
                 if change.newValue != self?.isLoading {
                     self?.isLoading = change.newValue

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -101,8 +101,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
     // MARK: - Lifecycle
 
     // swiftlint:disable:next function_body_length
-    @MainActor
-    init(tabID: NSManagedObjectID? = nil) {
+    @MainActor init(tabID: NSManagedObjectID? = nil) {
         self.tabID = tabID
         webView = WKWebView(frame: .zero, configuration: WebViewConfiguration())
         if !Bundle.main.isProduction, #available(iOS 16.4, macOS 13.3, *) {

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -59,6 +59,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
     @Published private(set) var articleBookmarked = false
     @Published private(set) var outlineItems = [OutlineItem]()
     @Published private(set) var outlineItemTree = [OutlineItem]()
+    @MainActor @Published private(set) var hasURL: Bool = false
     @MainActor @Published private(set) var url: URL? {
         didSet {
             if !FeatureFlags.hasLibrary, url == nil {
@@ -68,6 +69,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
                 bookmarkFetchedResultsController.fetchRequest.predicate = Self.bookmarksPredicateFor(url: url)
                 try? bookmarkFetchedResultsController.performFetch()
             }
+            hasURL = url != nil
         }
     }
     @Published var externalURL: URL?

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -51,6 +51,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
 
     // MARK: - Properties
 
+    @Published private(set) var isLoading: Bool?
     @Published private(set) var canGoBack = false
     @Published private(set) var canGoForward = false
     @Published private(set) var articleTitle: String = ""
@@ -87,6 +88,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
     }
 #endif
     let webView: WKWebView
+    private var isLoadingObserver: NSKeyValueObservation?
     private var canGoBackObserver: NSKeyValueObservation?
     private var canGoForwardObserver: NSKeyValueObservation?
     private var titleURLObserver: AnyCancellable?
@@ -158,6 +160,14 @@ final class BrowserViewModel: NSObject, ObservableObject,
         .sink { [weak self] title, url in
             guard let title, let url else { return }
             self?.didUpdate(title: title, url: url)
+        }
+
+        isLoadingObserver = webView.observe(\.isLoading, options: .new) { [weak self] webView, change in
+            Task { @MainActor in
+                if change.newValue != self?.isLoading {
+                    self?.isLoading = change.newValue
+                }
+            }
         }
     }
 

--- a/ViewModel/LaunchViewModel.swift
+++ b/ViewModel/LaunchViewModel.swift
@@ -25,9 +25,9 @@ enum LaunchSequence: Equatable {
     var shouldShowCatalog: Bool {
         switch self {
         case .loadingData: return true
-        case .webPage(_): return false
+        case .webPage: return false
         case .catalog(.fetching): return true
-        case .catalog(.welcome(_)): return true
+        case .catalog(.welcome): return true
         case .catalog(.list): return false
         }
     }
@@ -107,12 +107,7 @@ final class CatalogLaunchViewModel: LaunchViewModelBase {
             libraryState,
             browserIsLoading,
             hasSeenCategoriesOnce
-        ).sink { [weak self] (
-            hasZIMs: Bool,
-            libState: LibraryState,
-            isBrowserLoading: Bool?,
-            hasSeenCategories: Bool
-        ) in
+        ).sink { [weak self] (hasZIMs: Bool, libState: LibraryState, isBrowserLoading: Bool?, hasSeenCategories: Bool) in
             guard let self else { return }
 
             switch (isBrowserLoading, hasZIMs, libState) {

--- a/ViewModel/LaunchViewModel.swift
+++ b/ViewModel/LaunchViewModel.swift
@@ -66,7 +66,7 @@ final class NoCatalogLaunchViewModel: LaunchViewModelBase {
     init(browserIsLoading: Published<Bool?>.Publisher) {
         super.init()
         browserIsLoading.sink { [weak self] (isLoading: Bool?) in
-            guard let self else { return }
+            guard let self = self else { return }
             switch isLoading {
             case .none:
                 updateTo(.loadingData)
@@ -99,6 +99,7 @@ final class CatalogLaunchViewModel: LaunchViewModelBase {
         self.init(libraryState: library.$state, browserIsLoading: browser.$isLoading)
     }
 
+    // swiftlint:disable closure_parameter_position
     init(libraryState: Published<LibraryState>.Publisher,
          browserIsLoading: Published<Bool?>.Publisher) {
         super.init()
@@ -107,8 +108,13 @@ final class CatalogLaunchViewModel: LaunchViewModelBase {
             libraryState,
             browserIsLoading,
             hasSeenCategoriesOnce
-        ).sink { [weak self] (hasZIMs: Bool, libState: LibraryState, isBrowserLoading: Bool?, hasSeenCategories: Bool) in
-            guard let self else { return }
+        ).sink { [weak self] (
+            hasZIMs: Bool,
+            libState: LibraryState,
+            isBrowserLoading: Bool?,
+            hasSeenCategories: Bool
+        ) in
+            guard let self = self else { return }
 
             switch (isBrowserLoading, hasZIMs, libState) {
 
@@ -143,6 +149,7 @@ final class CatalogLaunchViewModel: LaunchViewModelBase {
             }
         }.store(in: &cancellables)
     }
+    // swiftlint:enable closure_parameter_position
 
     override func updateWith(hasZimFiles: Bool, hasSeenCategories: Bool) {
         hasZIMFiles.send(hasZimFiles)

--- a/ViewModel/LaunchViewModel.swift
+++ b/ViewModel/LaunchViewModel.swift
@@ -56,7 +56,7 @@ protocol LaunchProtocol: ObservableObject {
 /// while the main page is not fully loaded for the first time
 final class NoCatalogLaunchViewModel: LaunchViewModelBase {
 
-    private var wasLoaded = false
+    private static var wasLoaded = false
 
     convenience init(browser: BrowserViewModel) {
         self.init(browserIsLoading: browser.$isLoading)
@@ -71,13 +71,13 @@ final class NoCatalogLaunchViewModel: LaunchViewModelBase {
             case .none:
                 updateTo(.loadingData)
             case .some(true):
-                if !wasLoaded {
+                if !Self.wasLoaded {
                     updateTo(.loadingData)
                 } else {
                     updateTo(.webPage(isLoading: true))
                 }
             case .some(false):
-                wasLoaded = true
+                Self.wasLoaded = true
                 updateTo(.webPage(isLoading: false))
             }
         }.store(in: &cancellables)

--- a/ViewModel/LaunchViewModel.swift
+++ b/ViewModel/LaunchViewModel.swift
@@ -21,6 +21,16 @@ enum LaunchSequence: Equatable {
     case loadingData
     case webPage(isLoading: Bool)
     case catalog(CatalogSequence)
+
+    var shouldShowCatalog: Bool {
+        switch self {
+        case .loadingData: return true
+        case .webPage(_): return false
+        case .catalog(.fetching): return true
+        case .catalog(.welcome(_)): return true
+        case .catalog(.list): return false
+        }
+    }
 }
 
 enum CatalogSequence: Equatable {

--- a/ViewModel/LaunchViewModel.swift
+++ b/ViewModel/LaunchViewModel.swift
@@ -69,7 +69,7 @@ final class NoCatalogLaunchViewModel: LaunchViewModelBase {
     }
 
     override func updateWith(hasZimFiles: Bool) {
-        // to be ignored
+        // to be ignored on purpose
     }
 }
 
@@ -79,16 +79,17 @@ final class CatalogLaunchViewModel: LaunchViewModelBase {
     private var hasZIMFiles = CurrentValueSubject<Bool, Never>(false)
 
     convenience init(library: LibraryViewModel,
-                     browser: BrowserViewModel) {
+                     browser: BrowserViewModel,
+                     hasSeenCategories: AnyPublisher<Defaults.KeyChange<Bool>, Never>
+    ) {
         self.init(libraryState: library.$state,
                   browserIsLoading: browser.$isLoading,
-                  hasSeenCategories: Default(.hasSeenCategories).publisher
-        )
+                  hasSeenCategories: hasSeenCategories.map(\.newValue))
     }
 
     init(libraryState: Published<LibraryState>.Publisher,
          browserIsLoading: Published<Bool?>.Publisher,
-         hasSeenCategories: Published<Bool>.Publisher
+         hasSeenCategories: Publishers.Map<AnyPublisher<Defaults.KeyChange<Bool>, Never>, Bool>
     ) {
         super.init()
 

--- a/ViewModel/LaunchViewModel.swift
+++ b/ViewModel/LaunchViewModel.swift
@@ -1,0 +1,136 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+import Combine
+import Defaults
+
+enum LaunchSequence: Equatable {
+    case loadingData
+    case webPage(isLoading: Bool)
+    case catalog(CatalogSequence)
+}
+
+enum CatalogSequence: Equatable {
+    case fetching
+    case error
+    case list
+    case welcome(isCatalogLoading: Bool)
+}
+
+protocol LaunchViewModelProtocol {
+    var state: Published<LaunchSequence>.Publisher { get }
+}
+
+// MARK: No Library (custom apps)
+
+/// Keeps us int the .loadingData state,
+/// while the main page is not fully loaded for the first time
+@MainActor
+final class NoCatalogLaunchViewModel: LaunchViewModelBase {
+
+    private var wasLoaded = false
+
+    convenience init(browser: BrowserViewModel) {
+        self.init(browserIsLoading: browser.$isLoading)
+    }
+
+    /// - Parameter browserIsLoading: assumed to start with a nil value (see: WKWebView.isLoading)
+    init(browserIsLoading: Published<Bool?>.Publisher) {
+        super.init()
+        browserIsLoading.sink { [weak self] (isLoading: Bool?) in
+            guard let self else { return }
+            switch isLoading {
+            case .none:
+                updateTo(.loadingData)
+            case .some(true):
+                if !wasLoaded {
+                    updateTo(.loadingData)
+                } else {
+                    updateTo(.webPage(isLoading: true))
+                }
+            case .some(false):
+                wasLoaded = true
+                updateTo(.webPage(isLoading: false))
+            }
+        }.store(in: &cancellables)
+    }
+}
+
+// MARK: With Catalog Library
+@MainActor
+final class CatalogLaunchViewModel: LaunchViewModelBase {
+
+    convenience init(hasZIMFiles: Published<Bool>.Publisher,
+                     library: LibraryViewModel,
+                     browser: BrowserViewModel) {
+        self.init(hasZIMFiles: hasZIMFiles,
+                  libraryState: library.$state,
+                  browserIsLoading: browser.$isLoading,
+                  hasSeenCategories: { Defaults[.hasSeenCategories] })
+    }
+
+    init(hasZIMFiles: Published<Bool>.Publisher,
+         libraryState: Published<LibraryState>.Publisher,
+         browserIsLoading: Published<Bool?>.Publisher,
+         hasSeenCategories: @escaping () -> Bool) {
+        super.init()
+
+        hasZIMFiles.combineLatest(
+            libraryState,
+            browserIsLoading
+        ).sink { [weak self] (
+            hasZIMs: Bool,
+            libState: LibraryState,
+            isBrowserLoading: Bool?
+        ) in
+            guard let self else { return }
+
+            switch (isBrowserLoading, hasZIMs, libState) {
+
+            // MARK: initial app start state
+            case (_, _, .initial): updateTo(.loadingData)
+
+            // MARK: browser must be empty as there are no ZIMs:
+            case (_, false, .inProgress):
+                if hasSeenCategories() {
+                    updateTo(.catalog(.welcome(isCatalogLoading: true)))
+                } else {
+                    updateTo(.catalog(.fetching))
+                }
+            case (_, false, .complete): updateTo(.catalog(.welcome(isCatalogLoading: false)))
+            case (_, false, .error): updateTo(.catalog(.error))
+
+            // MARK: has zims and opens a new empty tab
+            case (.none, true, _): updateTo(.catalog(.list))
+
+            // MARK: actively browsing
+            case (.some(true), true, _): updateTo(.webPage(isLoading: true))
+            case (.some(false), true, _): updateTo(.webPage(isLoading: false))
+            }
+        }.store(in: &cancellables)
+    }
+}
+
+class LaunchViewModelBase: LaunchViewModelProtocol {
+    var state: Published<LaunchSequence>.Publisher { $currentState }
+    var cancellables = Set<AnyCancellable>()
+    @Published private var currentState: LaunchSequence = .loadingData
+
+    func updateTo(_ newState: LaunchSequence) {
+        guard newState != currentState else { return }
+        currentState = newState
+    }
+}

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -101,8 +101,9 @@ struct BrowserTab: View {
         @ObservedObject var model: LaunchModel
 
         var body: some View {
+            // swiftlint:disable:next redundant_discardable_let
             let _ = model.updateWith(hasZimFiles: !zimFiles.isEmpty,
-                                     hasSeenCategories: hasSeenCategories)
+                             hasSeenCategories: hasSeenCategories)
             GeometryReader { proxy in
                 Group {
                     if isSearching {
@@ -127,7 +128,9 @@ struct BrowserTab: View {
 #if os(macOS)
                                 .overlay(alignment: .bottomTrailing) {
                                     ContentSearchBar(
-                                        model: ContentSearchViewModel(findInWebPage: browser.webView.find(_:configuration:))
+                                        model: ContentSearchViewModel(
+                                            findInWebPage: browser.webView.find(_:configuration:)
+                                        )
                                     )
                                 }
 #endif

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -100,7 +100,6 @@ struct BrowserTab: View {
         @Default(.hasSeenCategories) private var hasSeenCategories
         @ObservedObject var model: LaunchModel
 
-
         var body: some View {
             let _ = model.updateWith(hasZimFiles: !zimFiles.isEmpty,
                                      hasSeenCategories: hasSeenCategories)

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -104,7 +104,6 @@ struct BrowserTab: View {
         var body: some View {
             let _ = model.updateWith(hasZimFiles: !zimFiles.isEmpty,
                                      hasSeenCategories: hasSeenCategories)
-            let _ = debugPrint("model.state: \(model.state)")
             GeometryReader { proxy in
                 Group {
                     if isSearching {

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -87,7 +87,10 @@ struct BrowserTab: View {
 
     private struct Content<LaunchModel>: View where LaunchModel: LaunchProtocol {
         @Environment(\.isSearching) private var isSearching
+        @Environment(\.horizontalSizeClass) private var horizontalSizeClass
         @EnvironmentObject private var browser: BrowserViewModel
+        @EnvironmentObject private var library: LibraryViewModel
+        @EnvironmentObject private var navigation: NavigationViewModel
         @FetchRequest(
             sortDescriptors: [NSSortDescriptor(keyPath: \ZimFile.size, ascending: false)],
             predicate: ZimFile.openedPredicate
@@ -135,11 +138,19 @@ struct BrowserTab: View {
                         case .catalog(.list):
                             LocalLibraryList()
                         case .catalog(.welcome(let welcomeViewState)):
-                            WelcomeCatalog(viewState: welcomeViewState, showLibrary: nil)
+                            WelcomeCatalog(viewState: welcomeViewState)
                         }
                     }
                 }
             }
+            .onChange(of: library.state) { state in
+                guard state == .complete else { return }
+                showTheLibrary()
+            }
+        }
+
+        private func showTheLibrary() {
+            navigation.currentItem = .categories
         }
     }
 }

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -150,6 +150,7 @@ struct BrowserTab: View {
         }
 
         private func showTheLibrary() {
+            guard model.state.shouldShowCatalog else { return }
             navigation.currentItem = .categories
         }
     }

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -14,18 +14,25 @@
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
 import SwiftUI
+import Defaults
 
 /// This is macOS and iPad only specific, not used on iPhone
 struct BrowserTab: View {
     @Environment(\.scenePhase) private var scenePhase
     @EnvironmentObject private var browser: BrowserViewModel
+    @EnvironmentObject private var library: LibraryViewModel
     @StateObject private var search = SearchViewModel()
 
     var body: some View {
-        Content().toolbar {
-            #if os(macOS)
+        let model = if FeatureFlags.hasLibrary {
+            CatalogLaunchViewModel(library: library, browser: browser)
+        } else {
+            NoCatalogLaunchViewModel(browser: browser)
+        }
+        Content(model: model).toolbar {
+#if os(macOS)
             ToolbarItemGroup(placement: .navigation) { NavigationButtons() }
-            #elseif os(iOS)
+#elseif os(iOS)
             ToolbarItemGroup(placement: .navigationBarLeading) {
                 if #unavailable(iOS 16) {
                     Button {
@@ -36,17 +43,17 @@ struct BrowserTab: View {
                 }
                 NavigationButtons()
             }
-            #endif
+#endif
             ToolbarItemGroup(placement: .primaryAction) {
                 OutlineButton()
                 ExportButton()
-                #if os(macOS)
+#if os(macOS)
                 PrintButton()
-                #endif
+#endif
                 BookmarkButton()
-                #if os(iOS)
+#if os(iOS)
                 ContentSearchButton()
-                #endif
+#endif
                 ArticleShortcutButtons(displayMode: .mainAndRandomArticle)
             }
         }
@@ -62,12 +69,12 @@ struct BrowserTab: View {
             }
         }
         .modify { view in
-            #if os(macOS)
+#if os(macOS)
             view.navigationTitle(browser.articleTitle.isEmpty ? Brand.appName : browser.articleTitle)
                 .navigationSubtitle(browser.zimFileName)
-            #elseif os(iOS)
+#elseif os(iOS)
             view
-            #endif
+#endif
         }
         .onAppear {
             browser.updateLastOpened()
@@ -78,11 +85,23 @@ struct BrowserTab: View {
         }
     }
 
-    struct Content: View {
+    private struct Content<LaunchModel>: View where LaunchModel: LaunchProtocol {
         @Environment(\.isSearching) private var isSearching
         @EnvironmentObject private var browser: BrowserViewModel
+        @FetchRequest(
+            sortDescriptors: [NSSortDescriptor(keyPath: \ZimFile.size, ascending: false)],
+            predicate: ZimFile.openedPredicate
+        ) private var zimFiles: FetchedResults<ZimFile>
+        /// this is still hacky a bit, as the change from here re-validates the view
+        /// which triggers the model to be revalidated
+        @Default(.hasSeenCategories) private var hasSeenCategories
+        @ObservedObject var model: LaunchModel
+
 
         var body: some View {
+            let _ = model.updateWith(hasZimFiles: !zimFiles.isEmpty,
+                                     hasSeenCategories: hasSeenCategories)
+            let _ = debugPrint("model.state: \(model.state)")
             GeometryReader { proxy in
                 Group {
                     if isSearching {
@@ -92,17 +111,32 @@ struct BrowserTab: View {
                             #elseif os(iOS)
                             .environment(\.horizontalSizeClass, proxy.size.width > 750 ? .regular : .compact)
                             #endif
-                    } else if browser.url == nil && FeatureFlags.hasLibrary {
-                        Welcome(showLibrary: nil)
                     } else {
-                        WebView().ignoresSafeArea()
-                        #if os(macOS)
-                            .overlay(alignment: .bottomTrailing) {
-                                ContentSearchBar(
-                                    model: ContentSearchViewModel(findInWebPage: browser.webView.find(_:configuration:))
-                                )
-                            }
-                        #endif
+                        switch model.state {
+                        case .loadingData:
+                            LoadingDataView()
+                        case .webPage(let isLoading):
+                            WebView()
+                                .ignoresSafeArea()
+                                .overlay {
+                                    if isLoading {
+                                        LoadingProgressView()
+                                    }
+                                }
+#if os(macOS)
+                                .overlay(alignment: .bottomTrailing) {
+                                    ContentSearchBar(
+                                        model: ContentSearchViewModel(findInWebPage: browser.webView.find(_:configuration:))
+                                    )
+                                }
+#endif
+                        case .catalog(.fetching):
+                            FetchingCatalogView()
+                        case .catalog(.list):
+                            LocalLibraryList()
+                        case .catalog(.welcome(let welcomeViewState)):
+                            WelcomeCatalog(viewState: welcomeViewState, showLibrary: nil)
+                        }
                     }
                 }
             }

--- a/Views/BuildingBlocks/LoadingView.swift
+++ b/Views/BuildingBlocks/LoadingView.swift
@@ -189,7 +189,16 @@ struct LoadingProgressView: View {
     }
 }
 
-struct LoadingView: View {
+struct FetchingCatalogView: View {
+    var body: some View {
+        ZStack {
+            LogoView()
+            LoadingMessageView(message: "welcome.button.status.fetching_catalog.text".localized)
+        }.ignoresSafeArea()
+    }
+}
+
+struct LoadingDataView: View {
     var body: some View {
         ZStack {
             LogoView()
@@ -199,5 +208,5 @@ struct LoadingView: View {
 }
 
 #Preview {
-    LoadingView()
+    LoadingDataView()
 }

--- a/Views/LocalLibraryList.swift
+++ b/Views/LocalLibraryList.swift
@@ -17,6 +17,7 @@ import SwiftUI
 import Combine
 import Defaults
 
+/// Displays a grid of available local ZIM files. Used on new tab.
 struct LocalLibraryList: View {
     @EnvironmentObject private var browser: BrowserViewModel
     @FetchRequest(

--- a/Views/LocalLibraryList.swift
+++ b/Views/LocalLibraryList.swift
@@ -1,0 +1,67 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import SwiftUI
+import Combine
+import Defaults
+
+struct LocalLibraryList: View {
+    @EnvironmentObject private var browser: BrowserViewModel
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \Bookmark.created, ascending: false)],
+        animation: .easeInOut
+    ) private var bookmarks: FetchedResults<Bookmark>
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \ZimFile.size, ascending: false)],
+        predicate: ZimFile.openedPredicate,
+        animation: .easeInOut
+    ) private var zimFiles: FetchedResults<ZimFile>
+
+    var body: some View {
+        LazyVGrid(
+            columns: ([GridItem(.adaptive(minimum: 250, maximum: 500), spacing: 12)]),
+            alignment: .leading,
+            spacing: 12
+        ) {
+            GridSection(title: "welcome.main_page.title".localized) {
+                ForEach(zimFiles) { zimFile in
+                    AsyncButtonView {
+                        guard let url = await ZimFileService.shared
+                            .getMainPageURL(zimFileID: zimFile.fileID) else { return }
+                        browser.load(url: url)
+                    } label: {
+                        ZimFileCell(zimFile, prominent: .name)
+                    } loading: {
+                        ZimFileCell(zimFile, prominent: .name, isLoading: true)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            if !bookmarks.isEmpty {
+                GridSection(title: "welcome.grid.bookmarks.title".localized) {
+                    ForEach(bookmarks.prefix(6)) { bookmark in
+                        Button {
+                            browser.load(url: bookmark.articleURL)
+                        } label: {
+                            ArticleCell(bookmark: bookmark)
+                        }
+                        .buttonStyle(.plain)
+                        .modifier(BookmarkContextMenu(bookmark: bookmark))
+                    }
+                }
+            }
+        }.modifier(GridCommon(edges: .all))
+    }
+}

--- a/Views/Welcome.swift
+++ b/Views/Welcome.swift
@@ -37,7 +37,7 @@ struct Welcome: View {
     let showLibrary: (() -> Void)?
 
     var body: some View {
-        if zimFiles.isEmpty {
+        if zimFiles.isEmpty || !FeatureFlags.hasLibrary {
             ZStack {
                 LogoView()
                 welcomeContent
@@ -56,7 +56,7 @@ struct Welcome: View {
                     }
                 }
             }.ignoresSafeArea()
-        } else {
+        } else if FeatureFlags.hasLibrary {
             LazyVGrid(
                 columns: ([GridItem(.adaptive(minimum: 250, maximum: 500), spacing: 12)]),
                 alignment: .leading,

--- a/Views/Welcome.swift
+++ b/Views/Welcome.swift
@@ -39,20 +39,24 @@ struct Welcome: View {
     var body: some View {
         if zimFiles.isEmpty || !FeatureFlags.hasLibrary {
             ZStack {
-                LogoView()
-                welcomeContent
-                    .onAppear {
-                        if !hasSeenCategories, library.state == .complete {
-                            // safety path for upgrading user with no ZIM files, but fetched categories
-                            // to make sure we do display the buttons
-                            hasSeenCategories = true
+                if !FeatureFlags.hasLibrary && browser.isLoading != false {
+                    LoadingView()
+                } else {
+                    LogoView()
+                    welcomeContent
+                        .onAppear {
+                            if !hasSeenCategories, library.state == .complete {
+                                // safety path for upgrading user with no ZIM files, but fetched categories
+                                // to make sure we do display the buttons
+                                hasSeenCategories = true
+                            }
                         }
-                    }
-                if library.state == .inProgress {
-                    if hasSeenCategories {
-                        LoadingProgressView()
-                    } else {
-                        LoadingMessageView(message: "welcome.button.status.fetching_catalog.text".localized)
+                    if library.state == .inProgress {
+                        if hasSeenCategories {
+                            LoadingProgressView()
+                        } else {
+                            LoadingMessageView(message: "welcome.button.status.fetching_catalog.text".localized)
+                        }
                     }
                 }
             }.ignoresSafeArea()

--- a/Views/WelcomeCatalog.swift
+++ b/Views/WelcomeCatalog.swift
@@ -17,56 +17,6 @@ import SwiftUI
 import Combine
 import Defaults
 
-
-struct LocalLibraryList: View {
-    @EnvironmentObject private var browser: BrowserViewModel
-    @FetchRequest(
-        sortDescriptors: [NSSortDescriptor(keyPath: \Bookmark.created, ascending: false)],
-        animation: .easeInOut
-    ) private var bookmarks: FetchedResults<Bookmark>
-    @FetchRequest(
-        sortDescriptors: [NSSortDescriptor(keyPath: \ZimFile.size, ascending: false)],
-        predicate: ZimFile.openedPredicate,
-        animation: .easeInOut
-    ) private var zimFiles: FetchedResults<ZimFile>
-
-    var body: some View {
-        LazyVGrid(
-            columns: ([GridItem(.adaptive(minimum: 250, maximum: 500), spacing: 12)]),
-            alignment: .leading,
-            spacing: 12
-        ) {
-            GridSection(title: "welcome.main_page.title".localized) {
-                ForEach(zimFiles) { zimFile in
-                    AsyncButtonView {
-                        guard let url = await ZimFileService.shared
-                            .getMainPageURL(zimFileID: zimFile.fileID) else { return }
-                        browser.load(url: url)
-                    } label: {
-                        ZimFileCell(zimFile, prominent: .name)
-                    } loading: {
-                        ZimFileCell(zimFile, prominent: .name, isLoading: true)
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            if !bookmarks.isEmpty {
-                GridSection(title: "welcome.grid.bookmarks.title".localized) {
-                    ForEach(bookmarks.prefix(6)) { bookmark in
-                        Button {
-                            browser.load(url: bookmark.articleURL)
-                        } label: {
-                            ArticleCell(bookmark: bookmark)
-                        }
-                        .buttonStyle(.plain)
-                        .modifier(BookmarkContextMenu(bookmark: bookmark))
-                    }
-                }
-            }
-        }.modifier(GridCommon(edges: .all))
-    }
-}
-
 struct WelcomeCatalog: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.verticalSizeClass) private var verticalSizeClass


### PR DESCRIPTION
Fixes: #1006

There must be quite some changes to achieve this.
Custom apps (the ones without catalog / library capability) have a different loading
sequence compared to Kiwix app, since we do not have the "Fetching catalog" part.

Also the views were too tightly coupled with the loading states and library. Eg: Welcome screen was coupled with WebView.

I separated out the sequence of loading and its possible states into a new place, and wrapped that into a protocol with 1 implementation for Kiwix, and one for custom apps without Library.

I have re-tested both Kiwix and custom apps on iPhone iPad and macOS.