### PR TITLE
Remove support button from custom apps

### DIFF
--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -195,8 +195,10 @@ struct RootView: View {
             }
             .frame(minWidth: 160)
             .safeAreaInset(edge: .bottom) {
-                SupportKiwixButton {
-                    openWindow(id: "donation")
+                if Payment.paymentButtonType() != nil {
+                    SupportKiwixButton {
+                        openWindow(id: "donation")
+                    }
                 }
             }
         } detail: {

--- a/Model/Payment.swift
+++ b/Model/Payment.swift
@@ -123,6 +123,9 @@ struct Payment {
     /// nil if Apple Pay is not supported
     /// or donation button, if all is OK
     static func paymentButtonType() -> PayWithApplePayButtonLabel? {
+        // only kiwix app is supporting donations atm.
+        guard case .kiwix = AppType.current else { return nil }
+        
         if PKPaymentAuthorizationController.canMakePayments() {
             return PayWithApplePayButtonLabel.donate
         }


### PR DESCRIPTION
Removing the support button from custom apps, to make sure they do not appear there.