### PR TITLE
Fix open new tab via http blank link (lost line in merge)

### DIFF
--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -561,6 +561,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
             externalURL = newURL
             return nil
         }
+        NotificationCenter.openURL(newURL, inNewTab: true)
         return nil
     }
 #endif


### PR DESCRIPTION
Fixes: #775 

It seems this line was lost in one of the git merges.
