### PR TITLE
Fix "flaky" unit-tests

### DIFF
--- a/Model/CategoriesToLanguage.swift
+++ b/Model/CategoriesToLanguage.swift
@@ -13,17 +13,23 @@
 // You should have received a copy of the GNU General Public License
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
-//
-//  CategoriesToLanguage.swift
-//  Kiwix
-//
-
 import Foundation
-import Defaults
 
-struct CategoriesToLanguages {
+protocol CategoriesProtocol {
+    func has(category: Category, inLanguages langCodes: Set<String>) -> Bool
+    func save(_ dictionary: [Category: Set<String>])
+    func allCategories() -> [Category]
+}
 
-    private let dictionary: [Category: Set<String>] = Defaults[.categoriesToLanguages]
+struct CategoriesToLanguages: CategoriesProtocol {
+    
+    private let defaults: Defaulting
+    private let dictionary: [Category: Set<String>]
+    
+    init(withDefaults defaults: Defaulting = UDefaults()) {
+        self.defaults = defaults
+        self.dictionary = defaults[.categoriesToLanguages]
+    }
 
     func has(category: Category, inLanguages langCodes: Set<String>) -> Bool {
         guard !langCodes.isEmpty, !dictionary.isEmpty else {
@@ -35,13 +41,13 @@ struct CategoriesToLanguages {
         return !languages.isDisjoint(with: langCodes)
     }
 
-    static func save(_ dictionary: [Category: Set<String>]) {
-        Defaults[.categoriesToLanguages] = dictionary
+    func save(_ dictionary: [Category: Set<String>]) {
+        defaults[.categoriesToLanguages] = dictionary
     }
 
-    static func allCategories() -> [Category] {
+    func allCategories() -> [Category] {
         let categoriesToLanguages = CategoriesToLanguages()
-        let contentLanguages = Defaults[.libraryLanguageCodes]
+        let contentLanguages = defaults[.libraryLanguageCodes]
         return Category.allCases.filter { (category: Category) in
             categoriesToLanguages.has(category: category, inLanguages: contentLanguages)
         }

--- a/Model/CategoriesToLanguage.swift
+++ b/Model/CategoriesToLanguage.swift
@@ -46,10 +46,9 @@ struct CategoriesToLanguages: CategoriesProtocol {
     }
 
     func allCategories() -> [Category] {
-        let categoriesToLanguages = CategoriesToLanguages()
         let contentLanguages = defaults[.libraryLanguageCodes]
         return Category.allCases.filter { (category: Category) in
-            categoriesToLanguages.has(category: category, inLanguages: contentLanguages)
+            has(category: category, inLanguages: contentLanguages)
         }
     }
 }

--- a/Model/Defaulting.swift
+++ b/Model/Defaulting.swift
@@ -1,0 +1,41 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+import Defaults
+
+protocol Defaulting: NSObjectProtocol {
+    subscript<Value: Defaults.Serializable>(key: Defaults.Key<Value>) -> Value { get set }
+}
+
+final class UDefaults: NSObject, Defaulting {
+    subscript<Value>(key: Defaults.Key<Value>) -> Value where Value : DefaultsSerializable {
+        get {
+            Defaults[key]
+        }
+        set {
+            Defaults[key] = newValue
+        }
+    }
+}
+
+/*
+ static subscript<Value: Serializable>(key: Key<Value>) -> Value {
+     get { key.suite[key] }
+     set {
+         key.suite[key] = newValue
+     }
+ }
+ */

--- a/Model/Defaulting.swift
+++ b/Model/Defaulting.swift
@@ -30,12 +30,3 @@ final class UDefaults: NSObject, Defaulting {
         }
     }
 }
-
-/*
- static subscript<Value: Serializable>(key: Key<Value>) -> Value {
-     get { key.suite[key] }
-     set {
-         key.suite[key] = newValue
-     }
- }
- */

--- a/SwiftUI/Model/Enum.swift
+++ b/SwiftUI/Model/Enum.swift
@@ -36,7 +36,7 @@ enum ActiveSheet: Hashable, Identifiable {
     case safari(url: URL)
 }
 
-enum Category: String, CaseIterable, Identifiable, LosslessStringConvertible {
+enum Category: String, CaseIterable, Identifiable, LosslessStringConvertible, Hashable {
     var description: String { rawValue }
 
     var id: String { rawValue }

--- a/Tests/LibraryRefreshViewModelTest.swift
+++ b/Tests/LibraryRefreshViewModelTest.swift
@@ -60,6 +60,7 @@ final class LibraryRefreshViewModelTest: XCTestCase {
     }
 
     private func makeOPDSData(zimFileID: UUID) -> String {
+        // swiftlint:disable line_length
         """
         <feed xmlns="http://www.w3.org/2005/Atom"
               xmlns:dc="http://purl.org/dc/terms/"
@@ -88,6 +89,7 @@ final class LibraryRefreshViewModelTest: XCTestCase {
           </entry>
         </feed>
         """
+        // swiftlint:enable line_length
     }
 
     /// Test time out fetching library data.
@@ -96,9 +98,12 @@ final class LibraryRefreshViewModelTest: XCTestCase {
         HTTPTestingURLProtocol.handler = { urlProtocol in
             urlProtocol.client?.urlProtocol(urlProtocol, didFailWithError: URLError(URLError.Code.timedOut))
         }
-
+        let testDefaults = TestDefaults()
+        testDefaults.setup()
         let viewModel = LibraryViewModel(urlSession: urlSession,
-                                         processFactory: { LibraryProcess() })
+                                         processFactory: { LibraryProcess(defaultState: .initial) },
+                                         defaults: testDefaults,
+                                         categories: CategoriesToLanguages(withDefaults: testDefaults))
         await viewModel.start(isUserInitiated: true)
         XCTAssert(viewModel.error is LibraryRefreshError)
         XCTAssertEqual(
@@ -119,8 +124,12 @@ final class LibraryRefreshViewModelTest: XCTestCase {
             urlProtocol.client?.urlProtocolDidFinishLoading(urlProtocol)
         }
 
+        let testDefaults = TestDefaults()
+        testDefaults.setup()
         let viewModel = LibraryViewModel(urlSession: urlSession,
-                                         processFactory: { LibraryProcess() })
+                                         processFactory: { LibraryProcess(defaultState: .initial) },
+                                         defaults: testDefaults,
+                                         categories: CategoriesToLanguages(withDefaults: testDefaults))
         await viewModel.start(isUserInitiated: true)
         XCTAssert(viewModel.error is LibraryRefreshError)
         XCTAssertEqual(
@@ -142,8 +151,12 @@ final class LibraryRefreshViewModelTest: XCTestCase {
             urlProtocol.client?.urlProtocolDidFinishLoading(urlProtocol)
         }
 
+        let testDefaults = TestDefaults()
+        testDefaults.setup()
         let viewModel = LibraryViewModel(urlSession: urlSession,
-                                         processFactory: { LibraryProcess() })
+                                         processFactory: { LibraryProcess(defaultState: .initial) },
+                                         defaults: testDefaults,
+                                         categories: CategoriesToLanguages(withDefaults: testDefaults))
         await viewModel.start(isUserInitiated: true)
         XCTExpectFailure("Requires work in dependency to resolve the issue.")
         XCTAssertEqual(
@@ -154,6 +167,7 @@ final class LibraryRefreshViewModelTest: XCTestCase {
 
     /// Test zim file entity is created, and metadata are saved when new zim file becomes available in online catalog.
     @MainActor
+    // swiftlint:disable:next function_body_length
     func testNewZimFileAndProperties() async throws {
         let zimFileID = UUID()
         HTTPTestingURLProtocol.handler = { urlProtocol in
@@ -166,9 +180,12 @@ final class LibraryRefreshViewModelTest: XCTestCase {
             urlProtocol.client?.urlProtocol(urlProtocol, didReceive: response, cacheStoragePolicy: .notAllowed)
             urlProtocol.client?.urlProtocolDidFinishLoading(urlProtocol)
         }
-
+        let testDefaults = TestDefaults()
+        testDefaults.setup()
         let viewModel = LibraryViewModel(urlSession: urlSession,
-                                         processFactory: { LibraryProcess() })
+                                         processFactory: { LibraryProcess(defaultState: .initial) },
+                                         defaults: testDefaults,
+                                         categories: CategoriesToLanguages(withDefaults: testDefaults))
         await viewModel.start(isUserInitiated: true)
 
         // check no error has happened
@@ -185,6 +202,7 @@ final class LibraryRefreshViewModelTest: XCTestCase {
         XCTAssertEqual(zimFile.id, zimFileID)
         XCTAssertEqual(zimFile.articleCount, 50001)
         XCTAssertEqual(zimFile.category, Category.wikipedia.rawValue)
+        // swiftlint:disable:next force_try
         XCTAssertEqual(zimFile.created, try! Date("2023-01-07T00:00:00Z", strategy: .iso8601))
         XCTAssertEqual(
             zimFile.downloadURL,
@@ -211,14 +229,21 @@ final class LibraryRefreshViewModelTest: XCTestCase {
         XCTAssertEqual(zimFile.persistentID, "wikipedia_en_top")
         XCTAssertEqual(zimFile.requiresServiceWorkers, false)
         XCTAssertEqual(zimFile.size, 6515656704)
+        
+        // clean up
+        context.delete(zimFile)
     }
 
     /// Test zim file deprecation
     @MainActor
     func testZimFileDeprecation() async throws {
+        let testDefaults = TestDefaults()
+        testDefaults.setup()
         // refresh library for the first time, which should create one zim file
         let viewModel = LibraryViewModel(urlSession: urlSession,
-                                         processFactory: { LibraryProcess() })
+                                         processFactory: { LibraryProcess(defaultState: .initial) },
+                                         defaults: testDefaults,
+                                         categories: CategoriesToLanguages(withDefaults: testDefaults))
         await viewModel.start(isUserInitiated: true)
         let context = Database.shared.viewContext
         let zimFile1 = try XCTUnwrap(try context.fetch(ZimFile.fetchRequest()).first)
@@ -241,6 +266,10 @@ final class LibraryRefreshViewModelTest: XCTestCase {
         // check there are two zim files in the database, and zim file 2 is not deprecated
         XCTAssertEqual(zimFiles.count, 2)
         XCTAssertEqual(zimFiles.filter({ $0.fileID == zimFile2.fileID }).count, 1)
+        
+        // clean up
+        context.delete(zimFile1)
+        context.delete(zimFile2)
     }
 }
 

--- a/Tests/LibraryRefreshViewModelTest.swift
+++ b/Tests/LibraryRefreshViewModelTest.swift
@@ -146,7 +146,7 @@ final class LibraryRefreshViewModelTest: XCTestCase {
                 url: URL.mock(),
                 statusCode: 200, httpVersion: nil, headerFields: [:]
             )!
-            urlProtocol.client?.urlProtocol(urlProtocol, didLoad: "Invalid OPDS Data".data(using: .utf8)!)
+            urlProtocol.client?.urlProtocol(urlProtocol, didLoad: Data("Invalid OPDS Data".utf8))
             urlProtocol.client?.urlProtocol(urlProtocol, didReceive: response, cacheStoragePolicy: .notAllowed)
             urlProtocol.client?.urlProtocolDidFinishLoading(urlProtocol)
         }
@@ -256,7 +256,7 @@ final class LibraryRefreshViewModelTest: XCTestCase {
         XCTAssertNotEqual(zimFile1.fileID, zimFile2.fileID)
 
         // set fileURLBookmark of zim file 2
-        zimFile2.fileURLBookmark = "/Users/tester/Downloads/file_url.zim".data(using: .utf8)
+        zimFile2.fileURLBookmark = Data("/Users/tester/Downloads/file_url.zim".utf8)
         try context.save()
 
         // refresh library for the third time

--- a/Tests/TestDefaults.swift
+++ b/Tests/TestDefaults.swift
@@ -15,27 +15,27 @@
 
 import Foundation
 import Defaults
+@testable import Kiwix
 
-public protocol Defaulting: NSObjectProtocol {
-    subscript<Value: Defaults.Serializable>(key: Defaults.Key<Value>) -> Value { get set }
-}
-
-final class UDefaults: NSObject, Defaulting {
+final class TestDefaults: NSObject, Defaulting {
+    
+    var dict: [Defaults.AnyKey: any DefaultsSerializable] = [:]
+    
+    func setup() {
+        self[.categoriesToLanguages] = [:]
+        self[.libraryAutoRefresh] = false
+        self[.libraryETag] = ""
+        self[.libraryUsingOldISOLangCodes] = false
+        self[.libraryLanguageCodes] = Set<String>()
+    }
+    
     subscript<Value>(key: Defaults.Key<Value>) -> Value where Value: DefaultsSerializable {
         get {
-            Defaults[key]
+            // swiftlint:disable:next force_cast
+            dict[key] as! Value
         }
         set {
-            Defaults[key] = newValue
+            dict[key] = newValue
         }
     }
 }
-
-/*
- static subscript<Value: Serializable>(key: Key<Value>) -> Value {
-     get { key.suite[key] }
-     set {
-         key.suite[key] = newValue
-     }
- }
- */

--- a/Views/Library/Library.swift
+++ b/Views/Library/Library.swift
@@ -26,9 +26,12 @@ struct Library: View {
     private let categories: [Category]
     let dismiss: (() -> Void)?
 
-    init(dismiss: (() -> Void)?) {
+    init(
+        dismiss: (() -> Void)?,
+        categories: [Category] = CategoriesToLanguages().allCategories()
+    ) {
         self.dismiss = dismiss
-        categories = CategoriesToLanguages.allCategories()
+        self.categories = categories
     }
 
     var body: some View {

--- a/Views/Library/ZimFilesCategories.swift
+++ b/Views/Library/ZimFilesCategories.swift
@@ -24,8 +24,11 @@ struct ZimFilesCategories: View {
     private var categories: [Category]
     private let dismiss: (() -> Void)?
 
-    init(dismiss: (() -> Void)?) {
-        categories = CategoriesToLanguages.allCategories()
+    init(
+        dismiss: (() -> Void)?,
+        categories: [Category] = CategoriesToLanguages().allCategories()
+    ) {
+        self.categories = categories
         selected = categories.first ?? .wikipedia
         self.dismiss = dismiss
     }


### PR DESCRIPTION
Fixes: #1071

After double checking our build issues, I realised that some unit-test results, are heavily dependent on User Defaults, which is a key/value storage by Apple, which is persisted across sessions.
By running the same Unit-tests several times (repeatedly without building) some of them might fail.

## Proposed solution:
- Wrap our user-default calls for those failing tests
- Use a test instance instead, that won't persist the results
- Also make sure that the created test db entries are cleaned-up properly