### PR TITLE
Remove support/donation for macOS FTP builds, as it's not supported outside of AppStore

### DIFF
--- a/.github/actions/xcbuild/action.yml
+++ b/.github/actions/xcbuild/action.yml
@@ -25,9 +25,6 @@ inputs:
   KEYCHAIN_PASSWORD:
     required: false
     default: mysecretpassword
-  KEYCHAIN_PROFILE:
-    required: false
-    default: build-profile
   XC_WORKSPACE:
     required: false
     default: Kiwix.xcodeproj/project.xcworkspace/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,6 +9,12 @@ name: CD
 # |-----------------|---------|------------------------|----------------|---------------------|
 # | UPLOAD_FOLDER   | nightly | -                      | -              | release/kiwix-macos |
 # |-----------------|---------|------------------------|----------------|---------------------|
+
+# Signing certificates:
+# - iOS/macOS + app-store: Apple Distribution
+# - iOS + FTP: Apple Development
+# - macOS + FTP: Developer ID
+
 on:
   schedule:
   - cron: '32 1 * * *' # Nightly download.kiwix.org @ 01:32
@@ -51,6 +57,11 @@ jobs:
 
     - name: Install python dependencies
       run: pip install pyyaml==6.0.1
+
+    # https://developer.apple.com/help/account/reference/supported-capabilities-macos
+    - name: Remove In App Purchase capability for macOS FTP (Developer ID signing)
+      if: matrix.platform == 'macOS' && matrix.destination == 'ftp'
+      run: sed -i '' '/in-app-payments/d' project.yml
 
     - name: Set VERSION from code
       shell: python
@@ -111,8 +122,8 @@ jobs:
       if: matrix.platform == 'iOS' && contains(env.UPLOAD_TO, matrix.destination)
       run: echo "EXTRA_XCODEBUILD=-sdk iphoneos ${{ env.APPLE_AUTH_PARAMS }}" >> $GITHUB_ENV
 
-    - name: Set EXTRA_XCODEBUILD for macOS AppStore
-      if: matrix.platform == 'macOS' && matrix.destination == 'app-store'
+    - name: Set macOS extra xcode params
+      if: matrix.platform == 'macOS' && contains(env.UPLOAD_TO, matrix.destination)
       run: echo "EXTRA_XCODEBUILD=${{ env.APPLE_AUTH_PARAMS }}" >> $GITHUB_ENV
 
     - name: Set macOS FTP export method, and Developer ID Certificate
@@ -150,7 +161,6 @@ jobs:
         DEPLOYMENT_SIGNING_CERTIFICATE_P12_PASSWORD: ${{ env.SIGNING_CERTIFICATE_P12_PASSWORD }}
         KEYCHAIN: ${{ env.KEYCHAIN }}
         KEYCHAIN_PASSWORD: ${{ env.KEYCHAIN_PASSWORD }}
-        KEYCHAIN_PROFILE: ${{ env.KEYCHAIN_PROFILE }}
         EXTRA_XCODEBUILD: ${{ env.EXTRA_XCODEBUILD }}
 
     - name: Add altool credentials to Keychain

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,7 +61,9 @@ jobs:
     # https://developer.apple.com/help/account/reference/supported-capabilities-macos
     - name: Remove In App Purchase capability for macOS FTP (Developer ID signing)
       if: matrix.platform == 'macOS' && matrix.destination == 'ftp'
-      run: sed -i '' '/in-app-payments/d' project.yml
+      run: |
+        sed -i '' '/in-app-payments/d' project.yml
+        plutil -insert HIDE_DONATION -bool true Support/Info.plist
 
     - name: Set VERSION from code
       shell: python

--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -196,7 +196,7 @@ struct RootView: View {
             }
             .frame(minWidth: 160)
             .safeAreaInset(edge: .bottom) {
-                if Payment.paymentButtonType() != nil && Brand.supportDonationVisible {
+                if Payment.paymentButtonType() != nil && Brand.hideDonation != true {
                     SupportKiwixButton {
                         openWindow(id: "donation")
                     }

--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -196,7 +196,7 @@ struct RootView: View {
             }
             .frame(minWidth: 160)
             .safeAreaInset(edge: .bottom) {
-                if Payment.paymentButtonType() != nil {
+                if Payment.paymentButtonType() != nil && Brand.supportDonationVisible {
                     SupportKiwixButton {
                         openWindow(id: "donation")
                     }

--- a/Model/Brand.swift
+++ b/Model/Brand.swift
@@ -54,7 +54,7 @@ enum Brand {
     // currently only used by Kiwix brand
     // if this is missing from project.yml we fall back to true
     // and hide the support for donation (for macOS FTP)
-    static let supportDonationVisible: Bool = Config.value(for: .supportDonationVisible) ?? false
+    static let hideDonation: Bool = Config.value(for: .hideDonation) ?? false
 
     static var defaultExternalLinkPolicy: ExternalLinkLoadingPolicy {
         guard let policyString: String = Config.value(for: .externalLinkDefaultPolicy),
@@ -85,7 +85,7 @@ enum Config: String {
     case showSearchSnippetInSettings = "SETTINGS_SHOW_SEARCH_SNIPPET"
     case aboutText = "CUSTOM_ABOUT_TEXT"
     case aboutWebsite = "CUSTOM_ABOUT_WEBSITE"
-    case supportDonationVisible = "SUPPORT_DONATION_VISIBLE"
+    case hideDonation = "HIDE_DONATION"
 
     static func value<T>(for key: Config) -> T? where T: LosslessStringConvertible {
         guard let object = Bundle.main.object(forInfoDictionaryKey: key.rawValue) else {

--- a/Model/Brand.swift
+++ b/Model/Brand.swift
@@ -51,6 +51,10 @@ enum Brand {
 
     static let aboutText: String = Config.value(for: .aboutText) ?? "settings.about.description".localized
     static let aboutWebsite: String = Config.value(for: .aboutWebsite) ?? "https://www.kiwix.org"
+    // currently only used by Kiwix brand
+    // if this is missing from project.yml we fall back to true
+    // and hide the support for donation (for macOS FTP)
+    static let supportDonationVisible: Bool = Config.value(for: .supportDonationVisible) ?? false
 
     static var defaultExternalLinkPolicy: ExternalLinkLoadingPolicy {
         guard let policyString: String = Config.value(for: .externalLinkDefaultPolicy),
@@ -81,6 +85,7 @@ enum Config: String {
     case showSearchSnippetInSettings = "SETTINGS_SHOW_SEARCH_SNIPPET"
     case aboutText = "CUSTOM_ABOUT_TEXT"
     case aboutWebsite = "CUSTOM_ABOUT_WEBSITE"
+    case supportDonationVisible = "SUPPORT_DONATION_VISIBLE"
 
     static func value<T>(for key: Config) -> T? where T: LosslessStringConvertible {
         guard let object = Bundle.main.object(forInfoDictionaryKey: key.rawValue) else {

--- a/Model/Brand.swift
+++ b/Model/Brand.swift
@@ -51,9 +51,10 @@ enum Brand {
 
     static let aboutText: String = Config.value(for: .aboutText) ?? "settings.about.description".localized
     static let aboutWebsite: String = Config.value(for: .aboutWebsite) ?? "https://www.kiwix.org"
-    // currently only used by Kiwix brand
-    // if this is missing from project.yml we fall back to true
-    // and hide the support for donation (for macOS FTP)
+    // currently only used under the Kiwix brand
+    // if this is set to true in Support/Info.plist the support/donation button is hidden (for macOS FTP)
+    // if not set, we fall back to false, and display the support/donation button
+    // for non Kiwix brands, it has no effect
     static let hideDonation: Bool = Config.value(for: .hideDonation) ?? false
 
     static var defaultExternalLinkPolicy: ExternalLinkLoadingPolicy {

--- a/project.yml
+++ b/project.yml
@@ -106,7 +106,6 @@ targets:
         INFOPLIST_KEY_CFBundleDisplayName: Kiwix
         INFOPLIST_FILE: Support/Info.plist
         INFOPLIST_KEY_UILaunchStoryboardName: SplashScreenKiwix.storyboard
-        SUPPORT_DONATION_VISIBLE: true # this line is removed for macOS FTP, where the donation pop up is hidden (not supported)
     sources:
       - path: Support
         excludes: 

--- a/project.yml
+++ b/project.yml
@@ -98,7 +98,7 @@ targets:
     entitlements:
       properties:
         com.apple.security.files.downloads.read-write: true
-        com.apple.developer.in-app-payments: [merchant.org.kiwix.apple]
+        com.apple.developer.in-app-payments: [merchant.org.kiwix.apple] # this line is removed for macOS FTP
     settings:
       base:
         MARKETING_VERSION: "3.7.0"
@@ -106,6 +106,7 @@ targets:
         INFOPLIST_KEY_CFBundleDisplayName: Kiwix
         INFOPLIST_FILE: Support/Info.plist
         INFOPLIST_KEY_UILaunchStoryboardName: SplashScreenKiwix.storyboard
+        SUPPORT_DONATION_VISIBLE: true # this line is removed for macOS FTP, where the donation pop up is hidden (not supported)
     sources:
       - path: Support
         excludes: 


### PR DESCRIPTION
Fixes: #1055

Fix the CD process for macOS.
In short: the in-app-purchase is not supported by Developer ID signed apps (outside of the App Store), therefore we cannot use that capability in the FTP macOS build.
Although Apple Pay itself is supported, the In App Purchase capability that we use (for Donation - a purchase of a non-digital good) is not supported.

The found Apple reference: 
https://developer.apple.com/help/account/reference/supported-capabilities-macos

We need a follow up discussion, if we want to hide the support button in this case or maybe use a direct link instead (since this build is not going to be verified by Apple).

----- 

After the comments, the approach is that we inject the `HIDE_DONATION: true` key/value into the Support/Info.plist file for macOS FTP builds. For all other builds the fallback value is `false` (do not hide). The condition whether to display the Support / Donation button is also dependent on the type of brand we run, therefore custom apps are not affected.
