### PR TITLE
Fix iPad split mode scroll to appear bottom bar

### DIFF
--- a/Views/BuildingBlocks/WebView.swift
+++ b/Views/BuildingBlocks/WebView.swift
@@ -164,7 +164,7 @@ extension WebViewController: UIScrollViewDelegate {
     
     func showBars(on navigationController: UINavigationController) {
         navigationController.setNavigationBarHidden(false, animated: true)
-        if Device.current == .iPhone {
+        if traitCollection.horizontalSizeClass == .compact {
             navigationController.setToolbarHidden(false, animated: true)
         }
     }


### PR DESCRIPTION
Fixes: #1097 

Make sure we apply the `showBars` function depending on the screen size type, and not on the device, this solves the issue on iPad split screen.