### PR TITLE
Update extension bundle ID

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -148,7 +148,7 @@ targets:
     supportedDestinations: [iOS]
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: self.Kiwix.widgets
+        PRODUCT_BUNDLE_IDENTIFIER: self.Kiwix.ioswidgets
         INFOPLIST_FILE: Widgets/Info.plist
     sources:
       - path: Common


### PR DESCRIPTION
It turns out we cannot register the former bundle ID, maybe it was used at some point,
so I am picking another one for our Widgets (Live Activity).

