### PR TITLE
Fix refresh ZimFile details after download

### DIFF
--- a/Views/Library/ZimFileDetail.swift
+++ b/Views/Library/ZimFileDetail.swift
@@ -87,13 +87,15 @@ struct ZimFileDetail: View {
         .modifier(FileLocator(isPresenting: $isPresentingFileLocator))
         .navigationTitle(zimFile.name)
         .navigationBarTitleDisplayMode(.inline)
-        .task {
-            if let zimFileName = await ZimFileService.shared.getFileURL(zimFileID: zimFile.fileID)?.lastPathComponent,
-               let documentDirectoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first,
-               FileManager.default.fileExists(atPath: documentDirectoryURL.appendingPathComponent(zimFileName).path) {
-                isInDocumentsDirectory = true
-            } else {
-                isInDocumentsDirectory = false
+        .onReceive(zimFile.publisher(for: \.fileURLBookmark)) { _ in
+            Task { @MainActor in
+                if let zimFileName = await ZimFileService.shared.getFileURL(zimFileID: zimFile.fileID)?.lastPathComponent,
+                   let documentDirectoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first,
+                   FileManager.default.fileExists(atPath: documentDirectoryURL.appendingPathComponent(zimFileName).path) {
+                    isInDocumentsDirectory = true
+                } else {
+                    isInDocumentsDirectory = false
+                }
             }
         }
         #endif

--- a/Views/Library/ZimFileDetail.swift
+++ b/Views/Library/ZimFileDetail.swift
@@ -89,9 +89,15 @@ struct ZimFileDetail: View {
         .navigationBarTitleDisplayMode(.inline)
         .onReceive(zimFile.publisher(for: \.fileURLBookmark)) { _ in
             Task { @MainActor in
-                if let zimFileName = await ZimFileService.shared.getFileURL(zimFileID: zimFile.fileID)?.lastPathComponent,
-                   let documentDirectoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first,
-                   FileManager.default.fileExists(atPath: documentDirectoryURL.appendingPathComponent(zimFileName).path) {
+                if let zimFileName = await ZimFileService.shared.getFileURL(
+                    zimFileID: zimFile.fileID
+                )?.lastPathComponent,
+                   let documentDirectoryURL = FileManager.default.urls(
+                    for: .documentDirectory, in: .userDomainMask
+                   ).first,
+                   FileManager.default.fileExists(
+                    atPath: documentDirectoryURL.appendingPathComponent(zimFileName).path
+                   ) {
                     isInDocumentsDirectory = true
                 } else {
                     isInDocumentsDirectory = false


### PR DESCRIPTION
Fixes: #1112 

Tested on iPhone and iPad. MacOS is not affected by the change, as it's within the ``#if os(iOS)`` macro, plus we always display the unlink action on macOS.

## BEFORE:

https://github.com/user-attachments/assets/2fd3a435-a405-46fc-9940-0151588bd76e

## AFTER:

https://github.com/user-attachments/assets/6e91ca41-afbb-48ff-a067-5ff84dc83f50

