### PR TITLE
1107 improve live activities

### DIFF
--- a/Common/DownloadActivityAttributes.swift
+++ b/Common/DownloadActivityAttributes.swift
@@ -51,6 +51,10 @@ public struct DownloadActivityAttributes: ActivityAttributes {
             return first.description
         }
         
+        public var estimatedTimeLeft: TimeInterval {
+            items.map(\.timeRemaining).max() ?? 0
+        }
+        
         public var progress: Double {
             progressFor(items: items).fractionCompleted
         }
@@ -65,6 +69,7 @@ public struct DownloadActivityAttributes: ActivityAttributes {
         let description: String
         let downloaded: Int64
         let total: Int64
+        let timeRemaining: TimeInterval
         var progress: Double {
             progressFor(items: [self]).fractionCompleted
         }
@@ -72,11 +77,12 @@ public struct DownloadActivityAttributes: ActivityAttributes {
             progressFor(items: [self]).localizedAdditionalDescription
         }
         
-        public init(uuid: UUID, description: String, downloaded: Int64, total: Int64) {
+        public init(uuid: UUID, description: String, downloaded: Int64, total: Int64, timeRemaining: TimeInterval) {
             self.uuid = uuid
             self.description = description
             self.downloaded = downloaded
             self.total = total
+            self.timeRemaining = timeRemaining
         }
     }
 }

--- a/Model/Utilities/DownloadTime.swift
+++ b/Model/Utilities/DownloadTime.swift
@@ -72,7 +72,7 @@ final class DownloadTime {
             time = key
             amount = value
         }
-        return mean(averages)
+        return weightedMean(averages)
     }
     
     private func latestSample() -> (CFTimeInterval, Int64)? {
@@ -83,11 +83,14 @@ final class DownloadTime {
         return (lastTime, lastAmount)
     }
     
-    private func mean(_ values: [Double]) -> Double {
-        let sum = values.reduce(0) { partialResult, value in
+    private func weightedMean(_ values: [Double]) -> Double {
+        let weights: [Double] = (0...values.count).map { (Double($0) + 1.0) * 1.2 }
+        let sum = values.enumerated().reduce(1.0) { partialResult, iterator in
+            partialResult + (iterator.element * weights[iterator.offset])
+        }
+        let sumOfWeights = weights.reduce(1.0) { partialResult, value in
             partialResult + value
         }
-        let average = sum / Double(values.count)
-        return average
+        return sum / sumOfWeights
     }
 }

--- a/Model/Utilities/DownloadTime.swift
+++ b/Model/Utilities/DownloadTime.swift
@@ -1,0 +1,93 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+import Foundation
+import QuartzCore
+
+@MainActor
+final class DownloadTime {
+    
+    /// Only consider these last seconds, when calculating the average speed, hence the remaining time
+    private let considerLastSeconds: Double
+    /// sampled data: seconds to % of download
+    private var samples: [CFTimeInterval: Int64] = [:]
+    private let totalAmount: Int64
+    
+    init(considerLastSeconds: Double = 2, total: Int64) {
+        assert(considerLastSeconds > 0)
+        assert(total > 0)
+        self.considerLastSeconds = considerLastSeconds
+        self.totalAmount = total
+    }
+    
+    func update(downloaded: Int64, now: CFTimeInterval = CACurrentMediaTime()) {
+        filterOutSamples(now: now)
+        samples[now] = downloaded
+    }
+    
+    func remainingTime(now: CFTimeInterval = CACurrentMediaTime()) -> CFTimeInterval {
+        filterOutSamples(now: now)
+        guard samples.count > 1, let (latestTime, latestAmount) = latestSample() else {
+            return .infinity
+        }
+        let average = averagePerSecond()
+        let remainingAmount = totalAmount - latestAmount
+        let remaingTime = Double(remainingAmount) / average - (now - latestTime)
+        guard remaingTime > 0 else {
+            return 0
+        }
+        return remaingTime
+    }
+    
+    private func filterOutSamples(now: CFTimeInterval) {
+        samples = samples.filter { time, _ in
+            time + considerLastSeconds > now
+        }
+    }
+    
+    private func averagePerSecond() -> Double {
+        var time: CFTimeInterval?
+        var amount: Int64?
+        var averages: [Double] = []
+        for key in samples.keys.sorted() {
+            let value = samples[key]!
+            if let time, let amount {
+                let took = key - time
+                let downloaded = value - amount
+                if took > 0, downloaded > 0 {
+                    averages.append(Double(downloaded) / took)
+                }
+            }
+            time = key
+            amount = value
+        }
+        return mean(averages)
+    }
+    
+    private func latestSample() -> (CFTimeInterval, Int64)? {
+        guard let lastTime = samples.keys.sorted().reversed().first,
+              let lastAmount = samples[lastTime] else {
+            return nil
+        }
+        return (lastTime, lastAmount)
+    }
+    
+    private func mean(_ values: [Double]) -> Double {
+        let sum = values.reduce(0) { partialResult, value in
+            partialResult + value
+        }
+        let average = sum / Double(values.count)
+        return average
+    }
+}

--- a/Views/LiveActivity/ActivityService.swift
+++ b/Views/LiveActivity/ActivityService.swift
@@ -150,7 +150,10 @@ final class ActivityService {
         }
     }
     
-    private func activityState(from state: [UUID: DownloadState], downloadTimes: [UUID: CFTimeInterval]) async -> DownloadActivityAttributes.ContentState {
+    private func activityState(
+        from state: [UUID: DownloadState],
+        downloadTimes: [UUID: CFTimeInterval]
+    ) async -> DownloadActivityAttributes.ContentState {
         var titles: [UUID: String] = [:]
         for key in state.keys {
             titles[key] = await getDownloadTitle(for: key)

--- a/Views/LiveActivity/ActivityService.swift
+++ b/Views/LiveActivity/ActivityService.swift
@@ -35,7 +35,7 @@ final class ActivityService {
         publisher: @MainActor @escaping () -> CurrentValueSubject<[UUID: DownloadState], Never> = {
             DownloadService.shared.progress.publisher
         },
-        updateFrequency: Double = 1,
+        updateFrequency: Double = 10,
         averageDownloadSpeedFromLastSeconds: Double = 30
     ) {
         assert(updateFrequency > 0)
@@ -116,9 +116,6 @@ final class ActivityService {
         
         let now = CACurrentMediaTime()
         for (key, state) in states {
-            if downloadTimes[key] == nil {
-                debugPrint("Creating new downloadTimes for \(key)")
-            }
             let downloadTime: DownloadTime = downloadTimes[key] ?? DownloadTime(
                 considerLastSeconds: averageDownloadSpeedFromLastSeconds,
                 total: state.total

--- a/Views/LiveActivity/ActivityService.swift
+++ b/Views/LiveActivity/ActivityService.swift
@@ -26,17 +26,22 @@ final class ActivityService {
     private var activity: Activity<DownloadActivityAttributes>?
     private var lastUpdate = CACurrentMediaTime()
     private let updateFrequency: Double
+    private let averageDownloadSpeedFromLastSeconds: Double
     private let publisher: @MainActor () -> CurrentValueSubject<[UUID: DownloadState], Never>
     private var isStarted: Bool = false
+    private var downloadTimes: [UUID: DownloadTime] = [:]
     
     init(
         publisher: @MainActor @escaping () -> CurrentValueSubject<[UUID: DownloadState], Never> = {
             DownloadService.shared.progress.publisher
         },
-        updateFrequency: Double = 1
+        updateFrequency: Double = 1,
+        averageDownloadSpeedFromLastSeconds: Double = 30
     ) {
         assert(updateFrequency > 0)
+        assert(averageDownloadSpeedFromLastSeconds > 0)
         self.updateFrequency = updateFrequency
+        self.averageDownloadSpeedFromLastSeconds = averageDownloadSpeedFromLastSeconds
         self.publisher = publisher
     }
     
@@ -51,9 +56,9 @@ final class ActivityService {
         }.store(in: &cancellables)
     }
     
-    private func start(with state: [UUID: DownloadState]) {
+    private func start(with state: [UUID: DownloadState], downloadTimes: [UUID: CFTimeInterval]) {
         Task {
-            let activityState = await activityState(from: state)
+            let activityState = await activityState(from: state, downloadTimes: downloadTimes)
             let content = ActivityContent(
                 state: activityState,
                 staleDate: nil,
@@ -81,9 +86,10 @@ final class ActivityService {
     }
     
     private func update(state: [UUID: DownloadState]) {
+        let downloadTimes: [UUID: CFTimeInterval] = updatedDownloadTimes(from: state)
         guard isStarted else {
             isStarted = true
-            start(with: state)
+            start(with: state, downloadTimes: downloadTimes)
             return
         }
         let now = CACurrentMediaTime()
@@ -92,7 +98,7 @@ final class ActivityService {
         }
         lastUpdate = now
         Task {
-            let activityState = await activityState(from: state)
+            let activityState = await activityState(from: state, downloadTimes: downloadTimes)
             await activity.update(
                 ActivityContent<DownloadActivityAttributes.ContentState>(
                     state: activityState,
@@ -102,11 +108,36 @@ final class ActivityService {
         }
     }
     
+    private func updatedDownloadTimes(from states: [UUID: DownloadState]) -> [UUID: CFTimeInterval] {
+        // remove the ones we should no longer track
+        downloadTimes = downloadTimes.filter({ key, _ in
+            states.keys.contains(key)
+        })
+        
+        let now = CACurrentMediaTime()
+        for (key, state) in states {
+            if downloadTimes[key] == nil {
+                debugPrint("Creating new downloadTimes for \(key)")
+            }
+            let downloadTime: DownloadTime = downloadTimes[key] ?? DownloadTime(
+                considerLastSeconds: averageDownloadSpeedFromLastSeconds,
+                total: state.total
+            )
+            downloadTime.update(downloaded: state.downloaded, now: now)
+            downloadTimes[key] = downloadTime
+        }
+        return downloadTimes.reduce(into: [:], { partialResult, time in
+            let (key, value) = time
+            partialResult.updateValue(value.remainingTime(now: now), forKey: key)
+        })
+    }
+    
     private func stop() {
         Task {
             await activity?.end(nil, dismissalPolicy: .immediate)
             activity = nil
             isStarted = false
+            downloadTimes = [:]
         }
     }
     
@@ -122,7 +153,7 @@ final class ActivityService {
         }
     }
     
-    private func activityState(from state: [UUID: DownloadState]) async -> DownloadActivityAttributes.ContentState {
+    private func activityState(from state: [UUID: DownloadState], downloadTimes: [UUID: CFTimeInterval]) async -> DownloadActivityAttributes.ContentState {
         var titles: [UUID: String] = [:]
         for key in state.keys {
             titles[key] = await getDownloadTitle(for: key)
@@ -135,7 +166,8 @@ final class ActivityService {
                     uuid: key,
                     description: titles[key] ?? key.uuidString,
                     downloaded: download.downloaded,
-                    total: download.total)
+                    total: download.total,
+                    timeRemaining: downloadTimes[key] ?? 0)
         })
     }
 }

--- a/Views/LiveActivity/ActivityService.swift
+++ b/Views/LiveActivity/ActivityService.swift
@@ -135,6 +135,10 @@ final class ActivityService {
             activity = nil
             isStarted = false
             downloadTimes = [:]
+            // make sure we clean up orphan activities of the same type as well
+            for activity in Activity<DownloadActivityAttributes>.activities {
+                await activity.end(nil, dismissalPolicy: .immediate)
+            }
         }
     }
     

--- a/Widgets/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/Widgets/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,6 +1,13 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "extended-gray",
+        "components" : {
+          "alpha" : "0.360",
+          "white" : "1.000"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/Widgets/DownloadsLiveActivity.swift
+++ b/Widgets/DownloadsLiveActivity.swift
@@ -17,21 +17,11 @@ import ActivityKit
 import WidgetKit
 import SwiftUI
 
-struct WidgetBackgroundModifier: ViewModifier {
-    func body(content: Content) -> some View {
-        if #available(iOSApplicationExtension 17.0, *) {
-            content.containerBackground(for: .widget) {
-                Color.widgetBackground
-            }
-            .activityBackgroundTint(Color("WidgetBackground"))
-        } else {
-            content
-                .activityBackgroundTint(Color("WidgetBackground"))
-        }
-    }
-}
-
 struct DownloadsLiveActivity: Widget {
+    var isActivityFullScreen: Bool = false
+//    @Environment(\.isActivityFullscreen) var isActivityFullScreen has a bug, when min iOS is 16
+//    https://developer.apple.com/forums/thread/763594
+    
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: DownloadActivityAttributes.self) { context in
             // Lock screen/banner UI goes here

--- a/Widgets/DownloadsLiveActivity.swift
+++ b/Widgets/DownloadsLiveActivity.swift
@@ -35,11 +35,16 @@ struct DownloadsLiveActivity: Widget {
                             .font(.headline)
                             .bold()
                         HStack {
-                            Text(timerInterval: Date.now...Date(timeInterval: context.state.estimatedTimeLeft, since: .now))
-                                .lineLimit(1)
-                                .multilineTextAlignment(.leading)
-                                .font(.caption)
-                                .tint(.secondary)
+                            Text(
+                                timerInterval: Date.now...Date(
+                                    timeInterval: context.state.estimatedTimeLeft,
+                                    since: .now
+                                )
+                            )
+                            .lineLimit(1)
+                            .multilineTextAlignment(.leading)
+                            .font(.caption)
+                            .tint(.secondary)
                             Text(context.state.progressDescription)
                                 .lineLimit(1)
                                 .multilineTextAlignment(.leading)

--- a/Widgets/DownloadsLiveActivity.swift
+++ b/Widgets/DownloadsLiveActivity.swift
@@ -18,7 +18,6 @@ import WidgetKit
 import SwiftUI
 
 struct DownloadsLiveActivity: Widget {
-    var isActivityFullScreen: Bool = false
 //    @Environment(\.isActivityFullscreen) var isActivityFullScreen has a bug, when min iOS is 16
 //    https://developer.apple.com/forums/thread/763594
     
@@ -35,11 +34,18 @@ struct DownloadsLiveActivity: Widget {
                             .multilineTextAlignment(.leading)
                             .font(.headline)
                             .bold()
-                        Text(context.state.progressDescription)
-                            .lineLimit(1)
-                            .multilineTextAlignment(.leading)
-                            .font(.caption)
-                            .tint(.secondary)
+                        HStack {
+                            Text(timerInterval: Date.now...Date(timeInterval: context.state.estimatedTimeLeft, since: .now))
+                                .lineLimit(1)
+                                .multilineTextAlignment(.leading)
+                                .font(.caption)
+                                .tint(.secondary)
+                            Text(context.state.progressDescription)
+                                .lineLimit(1)
+                                .multilineTextAlignment(.leading)
+                                .font(.caption)
+                                .tint(.secondary)
+                        }
                     }
                     Spacer()
                     ProgressView(value: context.state.progress)
@@ -111,13 +117,15 @@ extension DownloadActivityAttributes.ContentState {
                     uuid: UUID(),
                     description: "First item",
                     downloaded: 128,
-                    total: 256
+                    total: 256,
+                    timeRemaining: 3
                 ),
                 DownloadActivityAttributes.DownloadItem(
                     uuid: UUID(),
                     description: "2nd item",
                     downloaded: 90,
-                    total: 124
+                    total: 124,
+                    timeRemaining: 2
                 )
             ]
         )
@@ -131,13 +139,15 @@ extension DownloadActivityAttributes.ContentState {
                     uuid: UUID(),
                     description: "First item",
                     downloaded: 256,
-                    total: 256
+                    total: 256,
+                    timeRemaining: 0
                 ),
                 DownloadActivityAttributes.DownloadItem(
                     uuid: UUID(),
                     description: "2nd item",
                     downloaded: 110,
-                    total: 124
+                    total: 124,
+                    timeRemaining: 2
                 )
             ]
         )

--- a/Widgets/DownloadsLiveActivity.swift
+++ b/Widgets/DownloadsLiveActivity.swift
@@ -17,6 +17,20 @@ import ActivityKit
 import WidgetKit
 import SwiftUI
 
+struct WidgetBackgroundModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOSApplicationExtension 17.0, *) {
+            content.containerBackground(for: .widget) {
+                Color.widgetBackground
+            }
+            .activityBackgroundTint(Color("WidgetBackground"))
+        } else {
+            content
+                .activityBackgroundTint(Color("WidgetBackground"))
+        }
+    }
+}
+
 struct DownloadsLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: DownloadActivityAttributes.self) { context in
@@ -44,6 +58,7 @@ struct DownloadsLiveActivity: Widget {
                         .padding()
                 }
             }
+            .modifier(WidgetBackgroundModifier())
             
         } dynamicIsland: { context in
             DynamicIsland {
@@ -87,7 +102,7 @@ struct DownloadsLiveActivity: Widget {
             }
             .widgetURL(URL(string: "https://www.kiwix.org"))
             .keylineTint(Color.red)
-        }
+        }.containerBackgroundRemovable()
     }
 }
 

--- a/Widgets/Info.plist
+++ b/Widgets/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleDisplayName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>NSExtension</key>

--- a/Widgets/WidgetBackgroundModifier.swift
+++ b/Widgets/WidgetBackgroundModifier.swift
@@ -1,0 +1,31 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import SwiftUI
+
+struct WidgetBackgroundModifier: ViewModifier {
+    
+    func body(content: Content) -> some View {
+        if #available(iOSApplicationExtension 17.0, *) {
+            content.containerBackground(for: .widget) {
+                Color.widgetBackground
+            }
+            .activityBackgroundTint(Color("WidgetBackground"))
+        } else {
+            content
+                .activityBackgroundTint(Color("WidgetBackground"))
+        }
+    }
+}


### PR DESCRIPTION
Fixes: #1107 

## UI:
I have changed the background for the live-activity, so it matches the look and feel of other widgets on the Lock Screen. There's one issue though, Apple's environment property:
isActivityFullScreen has a bug, when we use min iOS is 16. According to their docs it has been "back-ported", but in reality using it is breaking the live-activity, and nothing will show up. Not using it is at the moment OK, I think, the only side effect is that in [iPhone standby mode](https://developer.apple.com/design/human-interface-guidelines/live-activities#StandBy) the live activity background is blurred instead of black. We can solve this only by updating to min iOS 17.

## Update frequency
Long story short: local updates for "live" activities can get ignored by the system if we send them too often. From my tests it seems that updating the live activity every 10 seconds, is stable enough.

I have added a countdown timer, that is showing that something is happening for the user, although the calculations of that is approximate. We update the "start time" of the counter every 10 sec, so it might jump up or down, plus we update the amount downloaded and the progress spinner every 10 sec.
