### PR TITLE
Fix library scroll issue - part 1

### DIFF
--- a/Views/BuildingBlocks/ArticleActions.swift
+++ b/Views/BuildingBlocks/ArticleActions.swift
@@ -1,0 +1,36 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import SwiftUI
+
+struct ArticleActions: View {
+    
+    let zimFileID: UUID
+    
+    var body: some View {
+        AsyncButton {
+            guard let url = await ZimFileService.shared.getMainPageURL(zimFileID: zimFileID) else { return }
+            NotificationCenter.openURL(url, inNewTab: true)
+        } label: {
+            Label(LocalString.library_zim_file_context_main_page_label, systemImage: "house")
+        }
+        AsyncButton {
+            guard let url = await ZimFileService.shared.getRandomPageURL(zimFileID: zimFileID) else { return }
+            NotificationCenter.openURL(url, inNewTab: true)
+        } label: {
+            Label(LocalString.library_zim_file_context_random_label, systemImage: "die.face.5")
+        }
+    }
+}

--- a/Views/BuildingBlocks/CopyPasteMenu.swift
+++ b/Views/BuildingBlocks/CopyPasteMenu.swift
@@ -1,0 +1,35 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct CopyPasteMenu: View {
+    
+    let downloadURL: URL
+    
+    var body: some View {
+        Button {
+            #if os(macOS)
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(downloadURL.absoluteString, forType: .string)
+            #elseif os(iOS)
+            UIPasteboard.general.setValue(downloadURL.absoluteString, forPasteboardType: UTType.url.identifier)
+            #endif
+        } label: {
+            Label(LocalString.library_zim_file_context_copy_url, systemImage: "doc.on.doc")
+        }
+    }
+}

--- a/Views/Library/Library.swift
+++ b/Views/Library/Library.swift
@@ -141,40 +141,10 @@ struct LibraryZimFileContext: ViewModifier {
             #endif
         }.contextMenu {
             if zimFile.fileURLBookmark != nil, !zimFile.isMissing {
-                Section { articleActions }
+                Section { ArticleActions(zimFileID: zimFile.fileID) }
             }
-            Section { supplementaryActions }
-        }
-    }
-
-    @ViewBuilder
-    var articleActions: some View {
-        AsyncButton {
-            guard let url = await ZimFileService.shared.getMainPageURL(zimFileID: zimFile.fileID) else { return }
-            NotificationCenter.openURL(url, inNewTab: true)
-        } label: {
-            Label(LocalString.library_zim_file_context_main_page_label, systemImage: "house")
-        }
-        AsyncButton {
-            guard let url = await ZimFileService.shared.getRandomPageURL(zimFileID: zimFile.fileID) else { return }
-            NotificationCenter.openURL(url, inNewTab: true)
-        } label: {
-            Label(LocalString.library_zim_file_context_random_label, systemImage: "die.face.5")
-        }
-    }
-
-    @ViewBuilder
-    var supplementaryActions: some View {
-        if let downloadURL = zimFile.downloadURL {
-            Button {
-                #if os(macOS)
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(downloadURL.absoluteString, forType: .string)
-                #elseif os(iOS)
-                UIPasteboard.general.setValue(downloadURL.absoluteString, forPasteboardType: UTType.url.identifier)
-                #endif
-            } label: {
-                Label(LocalString.library_zim_file_context_copy_url, systemImage: "doc.on.doc")
+            if let downloadURL = zimFile.downloadURL {
+                Section { CopyPasteMenu(downloadURL: downloadURL) }
             }
         }
     }

--- a/Views/Library/Library.swift
+++ b/Views/Library/Library.swift
@@ -134,7 +134,7 @@ struct LibraryZimFileContext<Content: View>: View {
         Group {
 #if os(macOS)
             Button {
-                viewModel.selectedZimFile = ZimFile
+                viewModel.selectedZimFile = zimFile
             } label: {
                 content
             }.buttonStyle(.plain)

--- a/Views/Library/Library.swift
+++ b/Views/Library/Library.swift
@@ -112,33 +112,39 @@ struct LibraryZimFileDetailSidePanel: ViewModifier {
 
 /// On macOS, converts the modified view to a Button that modifies the currently selected zim file
 /// On iOS, converts the modified view to a NavigationLink that goes to the zim file detail.
-struct LibraryZimFileContext: ViewModifier {
+struct LibraryZimFileContext<Content: View>: View {
     @EnvironmentObject private var viewModel: LibraryViewModel
-    @EnvironmentObject private var navigation: NavigationViewModel
-
-    let zimFile: ZimFile
-    let dismiss: (() -> Void)? // iOS only
-
-    init(zimFile: ZimFile, dismiss: (() -> Void)?) {
+    
+    private let content: Content
+    private let zimFile: ZimFile
+    /// iOS only
+    private let dismiss: (() -> Void)?
+    
+    init(
+        @ViewBuilder content: () -> Content,
+        zimFile: ZimFile,
+        dismiss: (() -> Void)? = nil
+    ) {
+        self.content = content()
         self.zimFile = zimFile
         self.dismiss = dismiss
     }
-
-    func body(content: Content) -> some View {
+    
+    var body: some View {
         Group {
-            #if os(macOS)
+#if os(macOS)
             Button {
-                viewModel.selectedZimFile = zimFile
+                viewModel.selectedZimFile = ZimFile
             } label: {
                 content
             }.buttonStyle(.plain)
-            #elseif os(iOS)
+#elseif os(iOS)
             NavigationLink {
                 ZimFileDetail(zimFile: zimFile, dismissParent: dismiss)
             } label: {
                 content
             }
-            #endif
+#endif
         }.contextMenu {
             if zimFile.fileURLBookmark != nil, !zimFile.isMissing {
                 Section { ArticleActions(zimFileID: zimFile.fileID) }
@@ -148,4 +154,5 @@ struct LibraryZimFileContext: ViewModifier {
             }
         }
     }
+    
 }

--- a/Views/Library/ZimFilesCategories.swift
+++ b/Views/Library/ZimFilesCategories.swift
@@ -139,14 +139,18 @@ private struct CategoryGrid: View {
                     ForEach(sections) { section in
                         if sections.count <= 1 {
                             ForEach(section) { zimFile in
-                                ZimFileCell(zimFile, prominent: .size)
-                                    .modifier(LibraryZimFileContext(zimFile: zimFile, dismiss: dismiss))
+                                LibraryZimFileContext(
+                                    content: { ZimFileCell(zimFile, prominent: .size) },
+                                    zimFile: zimFile,
+                                    dismiss: dismiss)
                             }
                         } else {
                             Section {
                                 ForEach(section) { zimFile in
-                                    ZimFileCell(zimFile, prominent: .size)
-                                        .modifier(LibraryZimFileContext(zimFile: zimFile, dismiss: dismiss))
+                                    LibraryZimFileContext(
+                                        content: { ZimFileCell(zimFile, prominent: .size) },
+                                        zimFile: zimFile,
+                                        dismiss: dismiss)
                                 }
                             } header: {
                                 SectionHeader(
@@ -244,8 +248,10 @@ private struct CategoryList: View {
                 }
             } else {
                 List(zimFiles, id: \.self, selection: $viewModel.selectedZimFile) { zimFile in
-                    ZimFileRow(zimFile)
-                        .modifier(LibraryZimFileContext(zimFile: zimFile, dismiss: dismiss))
+                    LibraryZimFileContext(
+                        content: { ZimFileRow(zimFile) },
+                        zimFile: zimFile,
+                        dismiss: dismiss)
                 }
                 #if os(macOS)
                 .listStyle(.inset)

--- a/Views/Library/ZimFilesDownloads.swift
+++ b/Views/Library/ZimFilesDownloads.swift
@@ -35,10 +35,11 @@ struct ZimFilesDownloads: View {
             alignment: .leading,
             spacing: 12
         ) {
-            ForEach(downloadTasks) { downloadTask in
-                if let zimFile = downloadTask.zimFile {
-                    DownloadTaskCell(zimFile).modifier(LibraryZimFileContext(zimFile: zimFile, dismiss: dismiss))
-                }
+            ForEach(downloadTasks.compactMap(\.zimFile)) { zimFile in
+                LibraryZimFileContext(
+                    content: { DownloadTaskCell(zimFile) },
+                    zimFile: zimFile,
+                    dismiss: dismiss)
             }
         }
         .modifier(GridCommon())

--- a/Views/Library/ZimFilesNew.swift
+++ b/Views/Library/ZimFilesNew.swift
@@ -42,28 +42,12 @@ struct ZimFilesNew: View {
             spacing: 12
         ) {
             ForEach(zimFiles.filter { filterPredicate.evaluate(with: $0) }, id: \.fileID) { zimFile in
-                Group {
-                #if os(macOS)
-                    Button {
-                        viewModel.selectedZimFile = zimFile
-                    } label: {
+                LibraryZimFileContext(
+                    content: {
                         ZimFileCell(zimFile, prominent: .name)
-                    }.buttonStyle(.plain)
-                #elseif os(iOS)
-                    NavigationLink {
-                        ZimFileDetail(zimFile: zimFile, dismissParent: dismiss)
-                    } label: {
-                        ZimFileCell(zimFile, prominent: .name)
-                    }
-                #endif
-                }.contextMenu {
-                    if zimFile.fileURLBookmark != nil, !zimFile.isMissing {
-                        Section { ArticleActions(zimFileID: zimFile.fileID) }
-                    }
-                    if let downloadURL = zimFile.downloadURL {
-                        Section { CopyPasteMenu(downloadURL: downloadURL) }
-                    }
-                }
+                    },
+                    zimFile: zimFile,
+                    dismiss: dismiss)
             }
         }
         .modifier(GridCommon())

--- a/Views/Library/ZimFilesNew.swift
+++ b/Views/Library/ZimFilesNew.swift
@@ -16,7 +16,7 @@
 import SwiftUI
 import Defaults
 
-final class ZimFilesNewViewModel: ObservableObject {
+private final class ViewModel: ObservableObject {
     
     @Published private(set) var zimFiles: [ZimFile] = []
     
@@ -95,7 +95,7 @@ struct ZimFilesNew: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @EnvironmentObject var library: LibraryViewModel
     @Default(.libraryLanguageCodes) private var languageCodes
-    @StateObject private var viewModel = ZimFilesNewViewModel()
+    @StateObject private var viewModel = ViewModel()
     @State private var searchText = ""
     let dismiss: (() -> Void)? // iOS only
 
@@ -171,25 +171,6 @@ struct ZimFilesNew: View {
             }
         }
     }
-
-//    private static func buildPredicate(searchText: String) -> NSPredicate {
-//        var predicates = [
-//            NSPredicate(format: "languageCode IN %@", Defaults[.libraryLanguageCodes]),
-//            NSPredicate(format: "requiresServiceWorkers == false")
-//        ]
-//        if let aMonthAgo = Calendar.current.date(byAdding: .month, value: -3, to: Date()) {
-//            predicates.append(NSPredicate(format: "created > %@", aMonthAgo as CVarArg))
-//        }
-//        if !searchText.isEmpty {
-//            predicates.append(
-//                NSCompoundPredicate(orPredicateWithSubpredicates: [
-//                    NSPredicate(format: "name CONTAINS[cd] %@", searchText),
-//                    NSPredicate(format: "fileDescription CONTAINS[cd] %@", searchText)
-//                ])
-//            )
-//        }
-//        return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
-//    }
 }
 
 @available(macOS 13.0, iOS 16.0, *)

--- a/Views/Library/ZimFilesNew.swift
+++ b/Views/Library/ZimFilesNew.swift
@@ -14,7 +14,6 @@
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
 import SwiftUI
-
 import Defaults
 
 /// A grid of zim files that are newly available.
@@ -42,9 +41,29 @@ struct ZimFilesNew: View {
             alignment: .leading,
             spacing: 12
         ) {
-            ForEach(zimFiles.filter { filterPredicate.evaluate(with: $0) }) { zimFile in
-                ZimFileCell(zimFile, prominent: .name)
-                    .modifier(LibraryZimFileContext(zimFile: zimFile, dismiss: dismiss))
+            ForEach(zimFiles.filter { filterPredicate.evaluate(with: $0) }, id: \.fileID) { zimFile in
+                Group {
+                #if os(macOS)
+                    Button {
+                        viewModel.selectedZimFile = zimFile
+                    } label: {
+                        ZimFileCell(zimFile, prominent: .name)
+                    }.buttonStyle(.plain)
+                #elseif os(iOS)
+                    NavigationLink {
+                        ZimFileDetail(zimFile: zimFile, dismissParent: dismiss)
+                    } label: {
+                        ZimFileCell(zimFile, prominent: .name)
+                    }
+                #endif
+                }.contextMenu {
+                    if zimFile.fileURLBookmark != nil, !zimFile.isMissing {
+                        Section { ArticleActions(zimFileID: zimFile.fileID) }
+                    }
+                    if let downloadURL = zimFile.downloadURL {
+                        Section { CopyPasteMenu(downloadURL: downloadURL) }
+                    }
+                }
             }
         }
         .modifier(GridCommon())

--- a/Views/Library/ZimFilesNew.swift
+++ b/Views/Library/ZimFilesNew.swift
@@ -66,7 +66,11 @@ private final class ViewModel: ObservableObject {
                 }
             }
         }
-        await MainActor.run { self.zimFiles = newZimFiles }
+        await MainActor.run {
+            withAnimation(.easeInOut) {
+                self.zimFiles = newZimFiles
+            }
+        }
     }
     
     private static func buildPredicate(searchText: String, languageCodes: Set<String>) -> NSPredicate {
@@ -112,6 +116,7 @@ struct ZimFilesNew: View {
                     },
                     zimFile: zimFile,
                     dismiss: dismiss)
+                .transition(AnyTransition.opacity)
             }
         }
         .modifier(GridCommon())

--- a/Views/Library/ZimFilesNew.swift
+++ b/Views/Library/ZimFilesNew.swift
@@ -16,7 +16,6 @@
 import SwiftUI
 import Defaults
 
-
 final class ZimFilesNewViewModel: ObservableObject {
     
     @Published private(set) var zimFiles: [ZimFile] = []

--- a/Views/Library/ZimFilesOpened.swift
+++ b/Views/Library/ZimFilesOpened.swift
@@ -35,8 +35,10 @@ struct ZimFilesOpened: View {
             spacing: 12
         ) {
             ForEach(zimFiles) { zimFile in
-                ZimFileCell(zimFile, prominent: .name).modifier(LibraryZimFileContext(zimFile: zimFile,
-                                                                                      dismiss: self.dismiss))
+                LibraryZimFileContext(
+                    content: { ZimFileCell(zimFile, prominent: .name) },
+                    zimFile: zimFile,
+                    dismiss: dismiss)
             }
         }
         .modifier(GridCommon(edges: .all))


### PR DESCRIPTION
Mostly fixing the issue: #1116

There were 2 main issues:
 - the [earlier search fix](https://github.com/kiwix/kiwix-apple/pull/1094), wasn't optimal in terms of scroll performance. 
 - it turned out that SwiftUI gets lost, when we use `ViewModifier` within a `ForEach` loop. It was hard to track down, but the possible explanation for this, is that SwiftUI needs to see the view hierarchy tree in order to make performant diffs between states. Now it seems that the former `ViewModifier` was erasing too heavily the type of the underlying views, and the performance got worse. Solution is to use view composition instead of view modifier.

The good news is that it performs a lot better now. 

There needs to be a part 2 fix for this as well. There's a "micro hang" on a freshly installed app, when scrolling the new section. This is mainly due to the icon loading and saving to the DB at the same time, for which I do have some solutions, but they are not final yet, so will leave them to a new PR.

Managed to add back the animations as well, and it works great:


https://github.com/user-attachments/assets/df8e10b0-5555-42b6-a37d-e6c8d2b52357


 