### PR TITLE
Replace viewModifiers with inline, use system colours

### DIFF
--- a/Views/BuildingBlocks/ArticleCell.swift
+++ b/Views/BuildingBlocks/ArticleCell.swift
@@ -57,12 +57,14 @@ struct ArticleCell: View {
         }
         .foregroundColor(.primary)
         .padding(12)
-        .modifier(CellBackground(isHovering: isHovering))
+        .background(CellBackground.colorFor(isHovering: isHovering))
+        .clipShape(CellBackground.clipShapeRectangle)
         .onHover { self.isHovering = $0 }
     }
 }
 
 struct ArticleCell_Previews: PreviewProvider {
+    
     static let result: SearchResult = {
         let result = SearchResult(zimFileID: UUID(), path: "", title: "Article Title")!
         result.snippet = NSAttributedString(string: """

--- a/Views/BuildingBlocks/DownloadTaskCell.swift
+++ b/Views/BuildingBlocks/DownloadTaskCell.swift
@@ -63,7 +63,8 @@ struct DownloadTaskCell: View {
             }.font(.caption).foregroundColor(.secondary)
         }
         .padding()
-        .modifier(CellBackground(isHovering: isHovering))
+        .background(CellBackground.colorFor(isHovering: isHovering))
+        .clipShape(CellBackground.clipShapeRectangle)
         .onHover { self.isHovering = $0 }
         .onReceive(DownloadService.shared.progress.publisher) { states in
             if let state = states[downloadZimFile.fileID] {

--- a/Views/BuildingBlocks/ZimFileCell.swift
+++ b/Views/BuildingBlocks/ZimFileCell.swift
@@ -81,7 +81,8 @@ struct ZimFileCell: View {
             }
         }
         .padding()
-        .modifier(CellBackground(isHovering: isHovering || isLoading))
+        .background(CellBackground.colorFor(isHovering: isHovering))
+        .clipShape(CellBackground.clipShapeRectangle)
         .modifier(LoadingOverlay(isLoading: isLoading))
         .onHover { self.isHovering = $0 }
     }

--- a/Views/Library/ZimFileDetail.swift
+++ b/Views/Library/ZimFileDetail.swift
@@ -377,30 +377,3 @@ private struct ServiceWorkerWarning: View {
         }
     }
 }
-
-struct ZimFileDetail_Previews: PreviewProvider {
-    static let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
-    static let zimFile: ZimFile = {
-        let zimFile = ZimFile(context: context)
-        zimFile.articleCount = 1000000
-        zimFile.category = "wikipedia"
-        zimFile.created = Date()
-        zimFile.downloadURL = URL(string: "https://www.example.com")
-        zimFile.fileID = UUID()
-        zimFile.fileDescription = "A very long description"
-        zimFile.flavor = "max"
-        zimFile.hasDetails = true
-        zimFile.hasPictures = false
-        zimFile.hasVideos = true
-        zimFile.languageCode = "en"
-        zimFile.mediaCount = 100
-        zimFile.name = "Wikipedia Zim File Name"
-        zimFile.persistentID = ""
-        zimFile.size = 1000000000
-        return zimFile
-    }()
-
-    static var previews: some View {
-        ZimFileDetail(zimFile: zimFile, dismissParent: nil).frame(width: 300).previewLayout(.sizeThatFits)
-    }
-}

--- a/Views/Library/ZimFileDetail.swift
+++ b/Views/Library/ZimFileDetail.swift
@@ -123,6 +123,9 @@ struct ZimFileDetail: View {
                 #endif
             }
             #if os(macOS)
+            .buttonStyle(.borderedProminent)
+            #endif
+            #if os(macOS)
             Action(title: LocalString.zim_file_action_reveal_in_finder_title) {
                 guard let url = await ZimFileService.shared.getFileURL(zimFileID: zimFile.id) else { return }
                 NSWorkspace.shared.activateFileViewerSelecting([url])
@@ -209,6 +212,9 @@ struct ZimFileDetail: View {
                 secondaryButton: .cancel()
             )
         }
+        #if os(macOS)
+        .buttonStyle(.borderedProminent)
+        #endif
     }
 
     @ViewBuilder

--- a/Views/Library/ZimFileDetailPreview.swift
+++ b/Views/Library/ZimFileDetailPreview.swift
@@ -1,0 +1,43 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import SwiftUI
+
+struct ZimFileDetail_Previews: PreviewProvider {
+    static let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+    static let zimFile: ZimFile = {
+        let zimFile = ZimFile(context: context)
+        zimFile.articleCount = 1000000
+        zimFile.category = "wikipedia"
+        zimFile.created = Date()
+        zimFile.downloadURL = URL(string: "https://www.example.com")
+        zimFile.fileID = UUID()
+        zimFile.fileDescription = "A very long description"
+        zimFile.flavor = "max"
+        zimFile.hasDetails = true
+        zimFile.hasPictures = false
+        zimFile.hasVideos = true
+        zimFile.languageCode = "en"
+        zimFile.mediaCount = 100
+        zimFile.name = "Wikipedia Zim File Name"
+        zimFile.persistentID = ""
+        zimFile.size = 1000000000
+        return zimFile
+    }()
+
+    static var previews: some View {
+        ZimFileDetail(zimFile: zimFile, dismissParent: nil).frame(width: 300).previewLayout(.sizeThatFits)
+    }
+}

--- a/Views/Library/ZimFileDetailPreview.swift
+++ b/Views/Library/ZimFileDetailPreview.swift
@@ -14,6 +14,7 @@
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
 import SwiftUI
+import CoreData
 
 struct ZimFileDetail_Previews: PreviewProvider {
     static let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)

--- a/Views/ViewModifiers/CellBackground.swift
+++ b/Views/ViewModifiers/CellBackground.swift
@@ -15,35 +15,18 @@
 
 import SwiftUI
 
-struct CellBackground: ViewModifier {
-    @Environment(\.colorScheme) var colorScheme: ColorScheme
-
-    let isHovering: Bool
-
-    func body(content: Content) -> some View {
-        content
-            .background(backgroundColor)
-            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+enum CellBackground {
+    #if os(macOS)
+    private static let normal: Color = Color(nsColor: NSColor.controlBackgroundColor)
+    private static let hover: Color = Color(nsColor: NSColor.selectedControlColor)
+    #else
+    private static let normal: Color = .secondaryBackground
+    private static let hover: Color = .tertiaryBackground
+    #endif
+    
+    static func colorFor(isHovering: Bool) -> Color {
+        isHovering ? hover : normal
     }
-
-    private var backgroundColor: Color {
-        switch (colorScheme, isHovering) {
-        case (.dark, true):
-            #if os(macOS)
-            return Color.background
-            #elseif os(iOS)
-            return Color.secondaryBackground
-            #endif
-        case (.dark, false):
-            return Color.tertiaryBackground
-        case (.light, true):
-            return Color(white: 0.9)
-        case (.light, false), (_, _):
-            #if os(macOS)
-            return Color.white
-            #elseif os(iOS)
-            return Color(white: 0.96)
-            #endif
-        }
-    }
+    
+    static let clipShapeRectangle = RoundedRectangle(cornerRadius: 12, style: .continuous)
 }


### PR DESCRIPTION
As part of the fix for: #1116 

I am replacing one more viewModifier to make it the scroll even faster, and not inject the colorscheme (light or dark mode) into each cell we have (which is expensive).
Instead of that, we can use the built in system colours, which look better, I think.
I also updated the Download and the "Open Main Page" button colours for macOS, to make those more prominent, and making it more obvious for our users what the next step should be.

**TLDR: It will be faster and nicer.**

Tested on iPad and macOS.

# BEFORE:
<img width="1259" alt="Screenshot 2025-02-19 at 00 36 26" src="https://github.com/user-attachments/assets/91c98eb1-9c5b-426f-8634-8879aab617ed" />
<img width="1259" alt="Screenshot 2025-02-19 at 00 36 43" src="https://github.com/user-attachments/assets/85552512-94af-4421-a249-87ff6a2bb863" />


# AFTER:

<img width="1259" alt="Screenshot 2025-02-19 at 00 27 59" src="https://github.com/user-attachments/assets/cdd8cdda-29c2-4a74-9890-5e1da72c10b7" />
<img width="1259" alt="Screenshot 2025-02-19 at 00 38 39" src="https://github.com/user-attachments/assets/09f84b22-541f-450f-a8ca-1e3860e6c8ca" />


