### PR TITLE
Update to macOS 14

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         platform: [iOS, macOS]
         destination: [app-store, ftp]
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - run: true
   build:
     needs: authorize
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       EXTRA_XCODEBUILD: ""
       APPLE_STORE_AUTH_KEY_PATH: /tmp/authkey.p8


### PR DESCRIPTION
As part of [this dependency update](https://github.com/kiwix/kiwix-apple/issues/1104), we need to update our CI CD to macOS 14 (and once this is merged to Xcode 16.2).
