### PR TITLE
1104 side menu optimisation

### DIFF
--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -37,7 +37,7 @@ final class CompactViewController: UIHostingController<AnyView>, UISearchControl
 
     init(navigation: NavigationViewModel) {
         self.navigation = navigation
-        searchViewModel = SearchViewModel()
+        searchViewModel = SearchViewModel.shared
         let searchResult = SearchResults().environmentObject(searchViewModel)
         searchController = UISearchController(searchResultsController: UIHostingController(rootView: searchResult))
         super.init(rootView: AnyView(CompactView()))

--- a/ViewModel/NavigationViewModel.swift
+++ b/ViewModel/NavigationViewModel.swift
@@ -97,6 +97,7 @@ final class NavigationViewModel: ObservableObject {
     /// Delete a single tab, and select another tab
     /// - Parameter tabID: ID of the tab to delete
     func deleteTab(tabID: NSManagedObjectID) {
+        let currentItemValue = currentItem
         Database.shared.performBackgroundTask { context in
             let sortByCreation = [NSSortDescriptor(key: "created", ascending: false)]
             guard let tabs: [Tab] = try? context.fetch(Tab.fetchRequest(predicate: nil,
@@ -105,7 +106,7 @@ final class NavigationViewModel: ObservableObject {
                 return
             }
             let newlySelectedTab: Tab?
-            if case let .tab(selectedTabID) = self.currentItem, selectedTabID == tabID {
+            if case let .tab(selectedTabID) = currentItemValue, selectedTabID == tabID {
                 // select a closeBy tab if the currently selected tab is to be deleted
                 newlySelectedTab = tabs.closeBy(toWhere: { $0.objectID == tabID }) ?? Self.makeTab(context: context)
             } else if tabs.count == 1 {

--- a/ViewModel/SearchViewModel.swift
+++ b/ViewModel/SearchViewModel.swift
@@ -23,13 +23,15 @@ final class SearchViewModel: NSObject, ObservableObject, NSFetchedResultsControl
     @Published private(set) var zimFiles: [UUID: ZimFile]  // ID of zim files that are included in search
     @Published private(set) var inProgress = false
     @Published private(set) var results = [SearchResult]()
+    
+    static let shared = SearchViewModel()
 
     private let fetchedResultsController: NSFetchedResultsController<ZimFile>
     private var searchSubscriber: AnyCancellable?
     @ZimActor
     private let queue = OperationQueue()
 
-    override init() {
+    override private init() {
         // initialize fetched results controller
         let predicate = NSPredicate(format: "includedInSearch == true AND fileURLBookmark != nil")
         fetchedResultsController = NSFetchedResultsController(
@@ -39,7 +41,7 @@ final class SearchViewModel: NSObject, ObservableObject, NSFetchedResultsControl
             cacheName: nil
         )
 
-        // initilze zim file IDs
+        // initialize zim file IDs
         try? fetchedResultsController.performFetch()
         zimFiles = fetchedResultsController.fetchedObjects?.reduce(into: [:]) { result, zimFile in
             result?[zimFile.fileID] = zimFile

--- a/Views/Bookmarks.swift
+++ b/Views/Bookmarks.swift
@@ -29,7 +29,7 @@ struct Bookmarks: View {
 
     var body: some View {
         LazyVGrid(columns: ([gridItem]), spacing: 12) {
-            ForEach(bookmarks) { bookmark in
+            ForEach(bookmarks, id: \.self) { bookmark in
                 Button {
                     NotificationCenter.openURL(bookmark.articleURL)
                     if horizontalSizeClass == .compact {
@@ -54,8 +54,8 @@ struct Bookmarks: View {
                 Message(text: LocalString.bookmark_overlay_empty_title)
             }
         }
+#if os(iOS)
         .toolbar {
-            #if os(iOS)
             ToolbarItem(placement: .navigationBarLeading) {
                 if #unavailable(iOS 16), horizontalSizeClass == .regular {
                     Button {
@@ -65,8 +65,8 @@ struct Bookmarks: View {
                     }
                 }
             }
-            #endif
         }
+#endif
     }
 
     private var gridItem: GridItem {

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -21,7 +21,7 @@ struct BrowserTab: View {
     @Environment(\.scenePhase) private var scenePhase
     @EnvironmentObject private var browser: BrowserViewModel
     @EnvironmentObject private var library: LibraryViewModel
-    @StateObject private var search = SearchViewModel()
+    @StateObject private var search = SearchViewModel.shared
 
     var body: some View {
         let model = if FeatureFlags.hasLibrary {


### PR DESCRIPTION
Improvements for the issue: #1115

Part of my investigation on why the side menu is "sticky" sometimes.
In short when we leave or arrive at a specific menu item we do certain DB operations, which can take some small amount of time. Additionally setting up some models might take additional time (eg: SearchViewModel).

**Solution:** 
We can do those appear/disappear operations asynchronously, and it's enough to have 1 SearchViewModel across the lifetime of the app, this makes the UI more smooth.

