### PR TITLE
Use progress bar with timer updates for live activities

### DIFF
--- a/Common/DownloadActivityAttributes.swift
+++ b/Common/DownloadActivityAttributes.swift
@@ -86,7 +86,14 @@ public struct DownloadActivityAttributes: ActivityAttributes {
             progressFor(items: [self]).localizedAdditionalDescription
         }
         
-        public init(uuid: UUID, description: String, downloaded: Int64, total: Int64, timeRemaining: TimeInterval, isPaused: Bool) {
+        public init(
+            uuid: UUID,
+            description: String,
+            downloaded: Int64,
+            total: Int64,
+            timeRemaining: TimeInterval,
+            isPaused: Bool
+        ) {
             self.uuid = uuid
             self.description = description
             self.downloaded = downloaded

--- a/Common/DownloadActivityAttributes.swift
+++ b/Common/DownloadActivityAttributes.swift
@@ -52,7 +52,15 @@ public struct DownloadActivityAttributes: ActivityAttributes {
         }
         
         public var estimatedTimeLeft: TimeInterval {
-            items.map(\.timeRemaining).max() ?? 0
+            items.filter { (item: DownloadActivityAttributes.DownloadItem) in
+                !item.isPaused
+            }.map(\.timeRemaining).max() ?? 0
+        }
+        
+        public var isAllPaused: Bool {
+            items.allSatisfy { (item: DownloadActivityAttributes.DownloadItem) in
+                item.isPaused
+            }
         }
         
         public var progress: Double {
@@ -70,6 +78,7 @@ public struct DownloadActivityAttributes: ActivityAttributes {
         let downloaded: Int64
         let total: Int64
         let timeRemaining: TimeInterval
+        let isPaused: Bool
         var progress: Double {
             progressFor(items: [self]).fractionCompleted
         }
@@ -77,12 +86,13 @@ public struct DownloadActivityAttributes: ActivityAttributes {
             progressFor(items: [self]).localizedAdditionalDescription
         }
         
-        public init(uuid: UUID, description: String, downloaded: Int64, total: Int64, timeRemaining: TimeInterval) {
+        public init(uuid: UUID, description: String, downloaded: Int64, total: Int64, timeRemaining: TimeInterval, isPaused: Bool) {
             self.uuid = uuid
             self.description = description
             self.downloaded = downloaded
             self.total = total
             self.timeRemaining = timeRemaining
+            self.isPaused = isPaused
         }
     }
 }

--- a/Model/DownloadService.swift
+++ b/Model/DownloadService.swift
@@ -26,6 +26,10 @@ struct DownloadState: Codable {
     let downloaded: Int64
     let total: Int64
     let resumeData: Data?
+    
+    var isPaused: Bool {
+        resumeData != nil
+    }
 
     static func empty() -> DownloadState {
         .init(downloaded: 0, total: 1, resumeData: nil)

--- a/Model/Downloads/DownloadService.swift
+++ b/Model/Downloads/DownloadService.swift
@@ -13,105 +13,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
-//
-//  DownloadService.swift
-//  Kiwix
-
 import Combine
 import CoreData
 import UserNotifications
 import os
-
-struct DownloadState: Codable {
-    let downloaded: Int64
-    let total: Int64
-    let resumeData: Data?
-    
-    var isPaused: Bool {
-        resumeData != nil
-    }
-
-    static func empty() -> DownloadState {
-        .init(downloaded: 0, total: 1, resumeData: nil)
-    }
-
-    init(downloaded: Int64, total: Int64, resumeData: Data?) {
-        guard total >= downloaded, total > 0 else {
-            assertionFailure("invalid download progress values: downloaded \(downloaded) total: \(total)")
-            self.downloaded = downloaded
-            self.total = downloaded
-            self.resumeData = resumeData
-            return
-        }
-        self.downloaded = downloaded
-        self.total = total
-        self.resumeData = resumeData
-    }
-
-    func updatedWith(downloaded: Int64, total: Int64) -> DownloadState {
-        DownloadState(downloaded: downloaded, total: total, resumeData: resumeData)
-    }
-
-    func updatedWith(resumeData: Data?) -> DownloadState {
-        DownloadState(downloaded: downloaded, total: total, resumeData: resumeData)
-    }
-}
-
-@MainActor
-final class DownloadTasksPublisher {
-
-    let publisher: CurrentValueSubject<[UUID: DownloadState], Never>
-    private var states = [UUID: DownloadState]()
-
-    init() {
-        publisher = CurrentValueSubject(states)
-        if let jsonData = UserDefaults.standard.object(forKey: "downloadStates") as? Data,
-           let storedStates = try? JSONDecoder().decode([UUID: DownloadState].self, from: jsonData) {
-            states = storedStates
-            publisher.send(states)
-        }
-    }
-
-    func updateFor(uuid: UUID, downloaded: Int64, total: Int64) {
-        if let state = states[uuid] {
-            states[uuid] = state.updatedWith(downloaded: downloaded, total: total)
-        } else {
-            states[uuid] = DownloadState(downloaded: downloaded, total: total, resumeData: nil)
-        }
-        publisher.send(states)
-        saveState()
-    }
-
-    func resetFor(uuid: UUID) {
-        states.removeValue(forKey: uuid)
-        publisher.send(states)
-        saveState()
-    }
-
-    func isEmpty() -> Bool {
-        states.isEmpty
-    }
-
-    func resumeDataFor(uuid: UUID) -> Data? {
-        states[uuid]?.resumeData
-    }
-
-    func updateFor(uuid: UUID, withResumeData resumeData: Data?) {
-        if let state = states[uuid] {
-            states[uuid] = state.updatedWith(resumeData: resumeData)
-            publisher.send(states)
-            saveState()
-        } else {
-            assertionFailure("there should be a download task for: \(uuid)")
-        }
-    }
-    
-    private func saveState() {
-        if let jsonStates = try? JSONEncoder().encode(states) {
-            UserDefaults.standard.setValue(jsonStates, forKey: "downloadStates")
-        }
-    }
-}
 
 final class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URLSessionDownloadDelegate {
     static let shared = DownloadService()

--- a/Model/Downloads/DownloadState.swift
+++ b/Model/Downloads/DownloadState.swift
@@ -1,0 +1,52 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+import Combine
+
+struct DownloadState: Codable {
+    let downloaded: Int64
+    let total: Int64
+    let resumeData: Data?
+    
+    var isPaused: Bool {
+        resumeData != nil
+    }
+
+    static func empty() -> DownloadState {
+        .init(downloaded: 0, total: 1, resumeData: nil)
+    }
+
+    init(downloaded: Int64, total: Int64, resumeData: Data?) {
+        guard total >= downloaded, total > 0 else {
+            assertionFailure("invalid download progress values: downloaded \(downloaded) total: \(total)")
+            self.downloaded = downloaded
+            self.total = downloaded
+            self.resumeData = resumeData
+            return
+        }
+        self.downloaded = downloaded
+        self.total = total
+        self.resumeData = resumeData
+    }
+
+    func updatedWith(downloaded: Int64, total: Int64) -> DownloadState {
+        DownloadState(downloaded: downloaded, total: total, resumeData: resumeData)
+    }
+
+    func updatedWith(resumeData: Data?) -> DownloadState {
+        DownloadState(downloaded: downloaded, total: total, resumeData: resumeData)
+    }
+}

--- a/Model/Downloads/DownloadTasksPublisher.swift
+++ b/Model/Downloads/DownloadTasksPublisher.swift
@@ -1,0 +1,73 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+import Combine
+
+@MainActor
+final class DownloadTasksPublisher {
+
+    let publisher: CurrentValueSubject<[UUID: DownloadState], Never>
+    private var states = [UUID: DownloadState]()
+
+    init() {
+        publisher = CurrentValueSubject(states)
+        if let jsonData = UserDefaults.standard.object(forKey: "downloadStates") as? Data,
+           let storedStates = try? JSONDecoder().decode([UUID: DownloadState].self, from: jsonData) {
+            states = storedStates
+            publisher.send(states)
+        }
+    }
+
+    func updateFor(uuid: UUID, downloaded: Int64, total: Int64) {
+        if let state = states[uuid] {
+            states[uuid] = state.updatedWith(downloaded: downloaded, total: total)
+        } else {
+            states[uuid] = DownloadState(downloaded: downloaded, total: total, resumeData: nil)
+        }
+        publisher.send(states)
+        saveState()
+    }
+
+    func resetFor(uuid: UUID) {
+        states.removeValue(forKey: uuid)
+        publisher.send(states)
+        saveState()
+    }
+
+    func isEmpty() -> Bool {
+        states.isEmpty
+    }
+
+    func resumeDataFor(uuid: UUID) -> Data? {
+        states[uuid]?.resumeData
+    }
+
+    func updateFor(uuid: UUID, withResumeData resumeData: Data?) {
+        if let state = states[uuid] {
+            states[uuid] = state.updatedWith(resumeData: resumeData)
+            publisher.send(states)
+            saveState()
+        } else {
+            assertionFailure("there should be a download task for: \(uuid)")
+        }
+    }
+    
+    private func saveState() {
+        if let jsonStates = try? JSONEncoder().encode(states) {
+            UserDefaults.standard.setValue(jsonStates, forKey: "downloadStates")
+        }
+    }
+}

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -611,8 +611,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
                 )
                 actions.append(
                     UIAction(title: LocalString.common_dialog_button_open_in_new_tab,
-                             image: UIImage(systemName: "doc.badge.plus")) { [weak self] _ in
-                                 guard let self else { return }
+                             image: UIImage(systemName: "doc.badge.plus")) { _ in
                                  Task { @MainActor in
                                      NotificationCenter.openURL(url, inNewTab: true)
                                  }

--- a/Views/LiveActivity/ActivityService.swift
+++ b/Views/LiveActivity/ActivityService.swift
@@ -112,7 +112,7 @@ final class ActivityService {
             if #available(iOS 17.2, *) {
                 // important to define a timestamp, this way iOS knows which updates
                 // can be dropped, if too many of them queues up
-                await activity.update(newContent, timestamp: .now)
+                await activity.update(newContent, timestamp: Date.now)
             } else {
                 await activity.update(newContent)
             }

--- a/Views/LiveActivity/ActivityService.swift
+++ b/Views/LiveActivity/ActivityService.swift
@@ -49,9 +49,9 @@ final class ActivityService {
         publisher().sink { [weak self] (state: [UUID: DownloadState]) in
             guard let self else { return }
             if state.isEmpty {
-                stop()
+                self.stop()
             } else {
-                update(state: state)
+                self.update(state: state)
             }
         }.store(in: &cancellables)
     }

--- a/Views/LiveActivity/ActivityService.swift
+++ b/Views/LiveActivity/ActivityService.swift
@@ -11,7 +11,7 @@
 // General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Kiwix; If not, see https://www.gnu.orgllll/llicenses/.
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
 #if os(iOS)
 

--- a/Widgets/DownloadsLiveActivity.swift
+++ b/Widgets/DownloadsLiveActivity.swift
@@ -102,7 +102,10 @@ struct DownloadsLiveActivity: Widget {
     }
     
     @ViewBuilder
-    private func progressFor(state: DownloadActivityAttributes.ContentState, timeInterval: ClosedRange<Date>) -> some View {
+    private func progressFor(
+        state: DownloadActivityAttributes.ContentState,
+        timeInterval: ClosedRange<Date>
+    ) -> some View {
         if !state.isAllPaused {
             ProgressView(timerInterval: timeInterval, countsDown: false, label: {
                 progressText(state.progressDescription)

--- a/Widgets/DownloadsLiveActivity.swift
+++ b/Widgets/DownloadsLiveActivity.swift
@@ -21,50 +21,47 @@ struct DownloadsLiveActivity: Widget {
 //    @Environment(\.isActivityFullscreen) var isActivityFullScreen has a bug, when min iOS is 16
 //    https://developer.apple.com/forums/thread/763594
     
+    /// A start time from the creation of the activity,
+    /// this way the progress bar is not jumping back to 0
+    private let startTime: Date = .now
+    
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: DownloadActivityAttributes.self) { context in
-            // Lock screen/banner UI goes here
+            // Lock screen/banner UI
+            let timeInterval = startTime...Date(
+                timeInterval: context.state.estimatedTimeLeft,
+                since: .now
+            )
             VStack {
                 HStack {
-                    KiwixLogo(maxHeight: 50)
-                        .padding()
                     VStack(alignment: .leading) {
                         Text(context.state.title)
                             .lineLimit(1)
                             .multilineTextAlignment(.leading)
                             .font(.headline)
                             .bold()
-                        HStack {
-                            Text(
-                                timerInterval: Date.now...Date(
-                                    timeInterval: context.state.estimatedTimeLeft,
-                                    since: .now
-                                )
-                            )
-                            .lineLimit(1)
-                            .multilineTextAlignment(.leading)
-                            .font(.caption)
-                            .tint(.secondary)
+                        ProgressView(timerInterval: timeInterval, countsDown: false, label: {
                             Text(context.state.progressDescription)
                                 .lineLimit(1)
-                                .multilineTextAlignment(.leading)
                                 .font(.caption)
                                 .tint(.secondary)
-                        }
+                        }, currentValueLabel: {
+                            Text(timerInterval: timeInterval)
+                                .font(.caption)
+                                .tint(.secondary)
+                        })
+                        .tint(Color.primary)
                     }
-                    Spacer()
-                    ProgressView(value: context.state.progress)
-                        .progressViewStyle(CircularProgressGaugeStyle(lineWidth: 5.7))
-                        .frame(width: 24, height: 24)
-                        .padding()
+                    .padding()
+                    KiwixLogo(maxHeight: 50)
+                        .padding(.trailing)
                 }
             }
             .modifier(WidgetBackgroundModifier())
             
         } dynamicIsland: { context in
             DynamicIsland {
-                // Expanded UI goes here.  Compose the expanded UI through
-                // various regions, like leading/trailing/center/bottom
+                // Expanded UI
                 DynamicIslandExpandedRegion(.leading) {
                     Spacer()
                     KiwixLogo(maxHeight: 50)
@@ -123,7 +120,7 @@ extension DownloadActivityAttributes.ContentState {
                     description: "First item",
                     downloaded: 128,
                     total: 256,
-                    timeRemaining: 3
+                    timeRemaining: 15
                 ),
                 DownloadActivityAttributes.DownloadItem(
                     uuid: UUID(),

--- a/Widgets/DownloadsLiveActivity.swift
+++ b/Widgets/DownloadsLiveActivity.swift
@@ -35,22 +35,8 @@ struct DownloadsLiveActivity: Widget {
             VStack {
                 HStack {
                     VStack(alignment: .leading) {
-                        Text(context.state.title)
-                            .lineLimit(1)
-                            .multilineTextAlignment(.leading)
-                            .font(.headline)
-                            .bold()
-                        ProgressView(timerInterval: timeInterval, countsDown: false, label: {
-                            Text(context.state.progressDescription)
-                                .lineLimit(1)
-                                .font(.caption)
-                                .tint(.secondary)
-                        }, currentValueLabel: {
-                            Text(timerInterval: timeInterval)
-                                .font(.caption)
-                                .tint(.secondary)
-                        })
-                        .tint(Color.primary)
+                        titleFor(context.state.title)
+                        progressFor(state: context.state, timeInterval: timeInterval)
                     }
                     .padding()
                     KiwixLogo(maxHeight: 50)
@@ -67,25 +53,13 @@ struct DownloadsLiveActivity: Widget {
                         timeInterval: context.state.estimatedTimeLeft,
                         since: .now
                     )
+                    
                     VStack(alignment: .leading) {
-                        Text(context.state.title)
-                            .lineLimit(1)
-                            .multilineTextAlignment(.leading)
-                            .font(.headline)
-                            .bold()
-                        ProgressView(timerInterval: timeInterval, countsDown: false, label: {
-                            Text(context.state.progressDescription)
-                                .lineLimit(1)
-                                .font(.caption)
-                                .tint(.secondary)
-                        }, currentValueLabel: {
-                            Text(timerInterval: timeInterval)
-                                .font(.caption)
-                                .tint(.secondary)
-                        })
-                        .tint(Color.primary)
+                        titleFor(context.state.title)
+                        progressFor(state: context.state, timeInterval: timeInterval)
+                        Spacer()
                     }
-                    .padding(.leading)
+                    .padding()
                     .dynamicIsland(verticalPlacement: .belowIfTooWide)
                 }
                 
@@ -109,6 +83,46 @@ struct DownloadsLiveActivity: Widget {
             .keylineTint(Color.red)
         }.containerBackgroundRemovable()
     }
+    
+    @ViewBuilder
+    private func titleFor(_ title: String) -> some View {
+        Text(title)
+            .lineLimit(1)
+            .frame(minWidth: 150, alignment: .leading)
+            .font(.headline)
+            .bold()
+    }
+    
+    @ViewBuilder
+    private func progressText(_ description: String) -> some View {
+        Text(description)
+            .lineLimit(1)
+            .font(.caption)
+            .tint(.secondary)
+    }
+    
+    @ViewBuilder
+    private func progressFor(state: DownloadActivityAttributes.ContentState, timeInterval: ClosedRange<Date>) -> some View {
+        if !state.isAllPaused {
+            ProgressView(timerInterval: timeInterval, countsDown: false, label: {
+                progressText(state.progressDescription)
+            }, currentValueLabel: {
+                Text(timerInterval: timeInterval)
+                    .font(.caption)
+                    .tint(.secondary)
+            })
+            .tint(Color.primary)
+        } else {
+            ProgressView(value: state.progress, label: {
+                progressText(state.progressDescription)
+            }, currentValueLabel: {
+                Label("", systemImage: "pause.fill")
+                    .font(.caption)
+                    .tint(.secondary)
+            })
+            .tint(Color.primary)
+        }
+    }
 }
 
 extension DownloadActivityAttributes {
@@ -127,14 +141,16 @@ extension DownloadActivityAttributes.ContentState {
                     description: "First item",
                     downloaded: 128,
                     total: 256,
-                    timeRemaining: 15
+                    timeRemaining: 15,
+                    isPaused: true
                 ),
                 DownloadActivityAttributes.DownloadItem(
                     uuid: UUID(),
                     description: "2nd item",
                     downloaded: 90,
                     total: 124,
-                    timeRemaining: 2
+                    timeRemaining: 2,
+                    isPaused: true
                 )
             ]
         )
@@ -149,14 +165,16 @@ extension DownloadActivityAttributes.ContentState {
                     description: "First item",
                     downloaded: 256,
                     total: 256,
-                    timeRemaining: 0
+                    timeRemaining: 0,
+                    isPaused: false
                 ),
                 DownloadActivityAttributes.DownloadItem(
                     uuid: UUID(),
                     description: "2nd item",
                     downloaded: 110,
                     total: 124,
-                    timeRemaining: 2
+                    timeRemaining: 2,
+                    isPaused: false
                 )
             ]
         )

--- a/Widgets/DownloadsLiveActivity.swift
+++ b/Widgets/DownloadsLiveActivity.swift
@@ -63,28 +63,35 @@ struct DownloadsLiveActivity: Widget {
             DynamicIsland {
                 // Expanded UI
                 DynamicIslandExpandedRegion(.leading) {
-                    Spacer()
-                    KiwixLogo(maxHeight: 50)
-                    Spacer()
-                }
-                DynamicIslandExpandedRegion(.trailing) {
-                    ProgressView(value: context.state.progress)
-                        .progressViewStyle(CircularProgressGaugeStyle(lineWidth: 11.4))
-                        .padding(6.0)
-                }
-                DynamicIslandExpandedRegion(.center) {
+                    let timeInterval = startTime...Date(
+                        timeInterval: context.state.estimatedTimeLeft,
+                        since: .now
+                    )
                     VStack(alignment: .leading) {
                         Text(context.state.title)
                             .lineLimit(1)
                             .multilineTextAlignment(.leading)
                             .font(.headline)
                             .bold()
-                        Text(context.state.progressDescription)
-                            .lineLimit(1)
-                            .multilineTextAlignment(.leading)
-                            .font(.caption)
-                            .tint(.secondary)
+                        ProgressView(timerInterval: timeInterval, countsDown: false, label: {
+                            Text(context.state.progressDescription)
+                                .lineLimit(1)
+                                .font(.caption)
+                                .tint(.secondary)
+                        }, currentValueLabel: {
+                            Text(timerInterval: timeInterval)
+                                .font(.caption)
+                                .tint(.secondary)
+                        })
+                        .tint(Color.primary)
                     }
+                    .padding(.leading)
+                    .dynamicIsland(verticalPlacement: .belowIfTooWide)
+                }
+                
+                DynamicIslandExpandedRegion(.trailing) {
+                    KiwixLogo(maxHeight: 50)
+                        .padding()
                 }
             } compactLeading: {
                 KiwixLogo()

--- a/Widgets/KiwixLogo.swift
+++ b/Widgets/KiwixLogo.swift
@@ -31,7 +31,7 @@ struct KiwixLogo: View {
             Image("KiwixLogo")
                 .resizable()
                 .scaledToFit()
-                .frame(width: maxHeight / 1.6182, height: maxHeight / 1.6182)
+                .frame(width: maxHeight * 0.75, height: maxHeight * 0.75)
         }
     }
 }


### PR DESCRIPTION
Fixes: #1107

-----

<img width="499" alt="Screenshot 2025-02-28 at 11 32 46" src="https://github.com/user-attachments/assets/5fdeb3ac-418a-4739-867d-e76b6687c603" />


## Solution

I replaced the progress indicator, with a linear bar that is updating constantly, so for our users it is more smooth. We do update the "real" progress every 10 seconds, which changes the amount of downloaded values displayed above the bar, and that updates the timer below the bar, and makes the bar either speed up or slow down.

I've also added a timestamp for each update, this helps the system decide which updates can be dropped if they do queue up, so once the system "unblocks" the live activity it can apply the latest update. 

I think, this is the best we can do considering the constraints that the iOS (especially above 18.0) puts on us.



## The Dynamic Island updated

<img width="514" alt="Screenshot 2025-02-28 at 11 31 56" src="https://github.com/user-attachments/assets/71d687ff-17d4-479a-91e9-657a6b6e4886" />


## The compact view remained unchanged:

<img width="394" alt="Screenshot 2025-02-28 at 09 31 54" src="https://github.com/user-attachments/assets/78d47529-fe19-48cc-88c3-1817decfa553" />


## Localisation

<img width="435" alt="Screenshot 2025-02-28 at 11 40 02" src="https://github.com/user-attachments/assets/14d5c839-b6b6-4cdb-88df-65c12b20b920" />


## Paused state

![Screenshot 2025-02-28 at 15 44 06](https://github.com/user-attachments/assets/ffc9ce30-b017-417f-b5ca-297a5625791e)


## Downloads file updates

The original `DownloadService` file became too long, so I split that up by classes and moved under a new folder.

