### PR TITLE
Live activities

### DIFF
--- a/App/App_iOS.swift
+++ b/App/App_iOS.swift
@@ -73,7 +73,14 @@ struct Kiwix: App {
                     if url.isFileURL {
                         NotificationCenter.openFiles([url], context: .file)
                     } else if url.isZIMURL {
-                        NotificationCenter.openURL(url)
+                        switch url {
+                        case DownloadActivityAttributes.downloadsDeepLink:
+                            if FeatureFlags.hasLibrary {
+                                navigation.showDownloads.send()
+                            }
+                        default:
+                            NotificationCenter.openURL(url)
+                        }
                     }
                 }
                 .task {

--- a/App/App_iOS.swift
+++ b/App/App_iOS.swift
@@ -25,17 +25,17 @@ struct Kiwix: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     private let fileMonitor: DirectoryMonitor
-//    private let activityService: ActivityService?
+    private let activityService: ActivityService?
 
     init() {
         fileMonitor = DirectoryMonitor(url: URL.documentDirectory) { LibraryOperations.scanDirectory($0) }
         // MARK: - live activities
-//        switch AppType.current {
-//        case .kiwix:
-//            activityService = ActivityService()
-//        case .custom:
-//            activityService = nil
-//        }
+        switch AppType.current {
+        case .kiwix:
+            activityService = ActivityService()
+        case .custom:
+            activityService = nil
+        }
         UNUserNotificationCenter.current().delegate = appDelegate
         // MARK: - migrations
         if !ProcessInfo.processInfo.arguments.contains("testing") {
@@ -85,7 +85,7 @@ struct Kiwix: App {
                         LibraryOperations.scanDirectory(URL.documentDirectory)
                         LibraryOperations.applyFileBackupSetting()
                         DownloadService.shared.restartHeartbeatIfNeeded()
-//                        activityService?.start()
+                        activityService?.start()
                     case let .custom(zimFileURL):
                         await LibraryOperations.open(url: zimFileURL)
                         ZimMigration.forCustomApps()

--- a/App/SplitViewController.swift
+++ b/App/SplitViewController.swift
@@ -21,6 +21,7 @@ import UIKit
 final class SplitViewController: UISplitViewController {
     let navigationViewModel: NavigationViewModel
     private var navigationItemObserver: AnyCancellable?
+    private var showDownloadsObserver: AnyCancellable?
     private var openURLObserver: NSObjectProtocol?
     private var hasZimFiles: Bool
 
@@ -74,6 +75,16 @@ final class SplitViewController: UISplitViewController {
                     self?.preferredDisplayMode = .automatic
                 }
             }
+        showDownloadsObserver = navigationViewModel
+            .showDownloads
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { [weak self] _ in
+                if self?.traitCollection.horizontalSizeClass == .regular {
+                    self?.navigationViewModel.currentItem = .downloads
+                }
+                // the compact one is triggered in CompactViewController
+        })
+        
         openURLObserver = NotificationCenter.default.addObserver(
             forName: .openURL, object: nil, queue: nil
         ) { [weak self] notification in

--- a/App/SplitViewController.swift
+++ b/App/SplitViewController.swift
@@ -79,8 +79,9 @@ final class SplitViewController: UISplitViewController {
             .showDownloads
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] _ in
-                if self?.traitCollection.horizontalSizeClass == .regular {
-                    self?.navigationViewModel.currentItem = .downloads
+                if self?.traitCollection.horizontalSizeClass == .regular,
+                   self?.navigationViewModel.currentItem != .downloads {
+                        self?.navigationViewModel.currentItem = .downloads
                 }
                 // the compact one is triggered in CompactViewController
         })

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 3.9.0
 
 # 3.8.0
+  - NEW:
+    - Live activities for downloads (@BPerlakiH #1096, #1105, #1106, #1114, #1126)
   - UPDATE:
     - Localisations (@translatewiki #1095, #1102, #1108)
     - Keyboard navigation improvements for macOS (@BPerlakiH #1084)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # 3.9.0
 
 # 3.8.0
-  - NEW:
-    - Live activities for downloads (@BPerlakiH #1096, #1105, #1106, #1114, #1126)
   - UPDATE:
     - Localisations (@translatewiki #1095, #1102, #1108)
     - Keyboard navigation improvements for macOS (@BPerlakiH #1084)

--- a/Common/DownloadActivityAttributes.swift
+++ b/Common/DownloadActivityAttributes.swift
@@ -18,6 +18,8 @@ import ActivityKit
 
 public struct DownloadActivityAttributes: ActivityAttributes {
     
+    static let downloadsDeepLink = URL(string: "zim://downloads")
+    
     private static func progressFor(items: [DownloadItem]) -> Progress {
         let sumOfTotal = items.reduce(0) { result, item in
             result + item.total

--- a/Model/Utilities/DownloadTime.swift
+++ b/Model/Utilities/DownloadTime.swift
@@ -43,11 +43,11 @@ final class DownloadTime {
         }
         let average = averagePerSecond()
         let remainingAmount = totalAmount - latestAmount
-        let remaingTime = Double(remainingAmount) / average - (now - latestTime)
-        guard remaingTime > 0 else {
+        let remainingTime = Double(remainingAmount) / average - (now - latestTime)
+        guard remainingTime > 0 else {
             return 0
         }
-        return remaingTime
+        return remainingTime
     }
     
     private func filterOutSamples(now: CFTimeInterval) {

--- a/ViewModel/NavigationViewModel.swift
+++ b/ViewModel/NavigationViewModel.swift
@@ -15,12 +15,15 @@
 
 import CoreData
 import WebKit
+import Combine
 
 @MainActor
 final class NavigationViewModel: ObservableObject {
     let uuid = UUID()
     // remained optional due to focusedSceneValue conformance
     @Published var currentItem: NavigationItem? = .loading
+    private(set) var showDownloads = PassthroughSubject<Void, Never>()
+    
     #if os(macOS)
     var isTerminating: Bool = false
     

--- a/Views/Library/Library.swift
+++ b/Views/Library/Library.swift
@@ -21,16 +21,19 @@ import Defaults
 /// Tabbed library view on iOS & iPadOS
 struct Library: View {
     @EnvironmentObject private var viewModel: LibraryViewModel
-    @SceneStorage("LibraryTabItem") private var tabItem: LibraryTabItem = .categories
+    @EnvironmentObject private var navigation: NavigationViewModel
+    @State private var tabItem: LibraryTabItem
     @Default(.hasSeenCategories) private var hasSeenCategories
     private let categories: [Category]
     let dismiss: (() -> Void)?
 
     init(
         dismiss: (() -> Void)?,
+        tabItem: LibraryTabItem = .categories,
         categories: [Category] = CategoriesToLanguages().allCategories()
     ) {
         self.dismiss = dismiss
+        self.tabItem = tabItem
         self.categories = categories
     }
 
@@ -70,6 +73,8 @@ struct Library: View {
             viewModel.start(isUserInitiated: false)
         }.onDisappear {
             hasSeenCategories = true
+        }.onReceive(navigation.showDownloads) { _ in
+            tabItem = .downloads
         }
     }
 }

--- a/Views/Library/Library.swift
+++ b/Views/Library/Library.swift
@@ -74,7 +74,9 @@ struct Library: View {
         }.onDisappear {
             hasSeenCategories = true
         }.onReceive(navigation.showDownloads) { _ in
-            tabItem = .downloads
+            if tabItem != .downloads {
+                tabItem = .downloads
+            }
         }
     }
 }

--- a/Views/LiveActivity/ActivityService.swift
+++ b/Views/LiveActivity/ActivityService.swift
@@ -35,7 +35,7 @@ final class ActivityService {
         publisher: @MainActor @escaping () -> CurrentValueSubject<[UUID: DownloadState], Never> = {
             DownloadService.shared.progress.publisher
         },
-        updateFrequency: Double = 10,
+        updateFrequency: Double = 2,
         averageDownloadSpeedFromLastSeconds: Double = 30
     ) {
         assert(updateFrequency > 0)

--- a/Widgets/DownloadsLiveActivity.swift
+++ b/Widgets/DownloadsLiveActivity.swift
@@ -36,6 +36,7 @@ struct DownloadsLiveActivity: Widget {
                 }
             }
             .modifier(WidgetBackgroundModifier())
+            .widgetURL(DownloadActivityAttributes.downloadsDeepLink)
             
         } dynamicIsland: { context in
             DynamicIsland {

--- a/Widgets/DownloadsLiveActivity.swift
+++ b/Widgets/DownloadsLiveActivity.swift
@@ -21,22 +21,14 @@ struct DownloadsLiveActivity: Widget {
 //    @Environment(\.isActivityFullscreen) var isActivityFullScreen has a bug, when min iOS is 16
 //    https://developer.apple.com/forums/thread/763594
     
-    /// A start time from the creation of the activity,
-    /// this way the progress bar is not jumping back to 0
-    private let startTime: Date = .now
-    
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: DownloadActivityAttributes.self) { context in
             // Lock screen/banner UI
-            let timeInterval = startTime...Date(
-                timeInterval: context.state.estimatedTimeLeft,
-                since: .now
-            )
             VStack {
                 HStack {
                     VStack(alignment: .leading) {
                         titleFor(context.state.title)
-                        progressFor(state: context.state, timeInterval: timeInterval)
+                        progressFor(state: context.state)
                     }
                     .padding()
                     KiwixLogo(maxHeight: 50)
@@ -49,14 +41,9 @@ struct DownloadsLiveActivity: Widget {
             DynamicIsland {
                 // Expanded UI
                 DynamicIslandExpandedRegion(.leading) {
-                    let timeInterval = startTime...Date(
-                        timeInterval: context.state.estimatedTimeLeft,
-                        since: .now
-                    )
-                    
                     VStack(alignment: .leading) {
                         titleFor(context.state.title)
-                        progressFor(state: context.state, timeInterval: timeInterval)
+                        progressFor(state: context.state)
                         Spacer()
                     }
                     .padding()
@@ -79,7 +66,7 @@ struct DownloadsLiveActivity: Widget {
                     .progressViewStyle(CircularProgressGaugeStyle(lineWidth: 5.7))
                     .frame(width: 24, height: 24)
             }
-            .widgetURL(URL(string: "https://www.kiwix.org"))
+            .widgetURL(URL(string: "zim://downloads"))
             .keylineTint(Color.red)
         }.containerBackgroundRemovable()
     }
@@ -101,11 +88,25 @@ struct DownloadsLiveActivity: Widget {
             .tint(.secondary)
     }
     
+    private func currentTimeInterval(
+        state: DownloadActivityAttributes.ContentState
+    ) -> ClosedRange<Date> {
+        if state.progress < 1 {
+            let timePassed: TimeInterval = state.progress / (1 - state.progress) * state.estimatedTimeLeft
+            return Date(timeInterval: 0 - timePassed, since: .now)...Date(
+                timeInterval: state.estimatedTimeLeft,
+                since: .now
+            )
+        } else {
+            return Date(timeIntervalSinceNow: 0)...Date(timeIntervalSinceNow: 0)
+        }
+    }
+    
     @ViewBuilder
     private func progressFor(
-        state: DownloadActivityAttributes.ContentState,
-        timeInterval: ClosedRange<Date>
+        state: DownloadActivityAttributes.ContentState
     ) -> some View {
+        let timeInterval = currentTimeInterval(state: state)
         if !state.isAllPaused {
             ProgressView(timerInterval: timeInterval, countsDown: false, label: {
                 progressText(state.progressDescription)
@@ -146,14 +147,6 @@ extension DownloadActivityAttributes.ContentState {
                     total: 256,
                     timeRemaining: 15,
                     isPaused: true
-                ),
-                DownloadActivityAttributes.DownloadItem(
-                    uuid: UUID(),
-                    description: "2nd item",
-                    downloaded: 90,
-                    total: 124,
-                    timeRemaining: 2,
-                    isPaused: true
                 )
             ]
         )
@@ -176,7 +169,7 @@ extension DownloadActivityAttributes.ContentState {
                     description: "2nd item",
                     downloaded: 110,
                     total: 124,
-                    timeRemaining: 2,
+                    timeRemaining: 20,
                     isPaused: false
                 )
             ]

--- a/Widgets/DownloadsLiveActivity.swift
+++ b/Widgets/DownloadsLiveActivity.swift
@@ -66,7 +66,7 @@ struct DownloadsLiveActivity: Widget {
                     .progressViewStyle(CircularProgressGaugeStyle(lineWidth: 5.7))
                     .frame(width: 24, height: 24)
             }
-            .widgetURL(URL(string: "zim://downloads"))
+            .widgetURL(DownloadActivityAttributes.downloadsDeepLink)
             .keylineTint(Color.red)
         }.containerBackgroundRemovable()
     }

--- a/project.yml
+++ b/project.yml
@@ -121,10 +121,10 @@ targets:
       - path: Kiwix/SplashScreenKiwix.storyboard
         destinationFilters:
           - iOS
-    # dependencies:
-    #   - target: Widgets
-    #     destinationFilters:
-    #       - iOS
+    dependencies:
+      - target: Widgets
+        destinationFilters:
+          - iOS
   UnitTests:
     type: bundle.unit-test
     supportedDestinations: [iOS, macOS]
@@ -143,19 +143,19 @@ targets:
       - path: Tests
     dependencies:
       - target: Kiwix
-  # Widgets:
-  #   type: app-extension
-  #   supportedDestinations: [iOS]
-  #   settings:
-  #     base:
-  #       PRODUCT_BUNDLE_IDENTIFIER: self.Kiwix.ioswidgets
-  #       INFOPLIST_FILE: Widgets/Info.plist
-  #   sources:
-  #     - path: Common
-  #     - path: Widgets
-  #   dependencies:
-  #     - framework: SwiftUI.framework
-  #     - framework: WidgetKit.framework
+  Widgets:
+    type: app-extension
+    supportedDestinations: [iOS]
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: self.Kiwix.ioswidgets
+        INFOPLIST_FILE: Widgets/Info.plist
+    sources:
+      - path: Common
+      - path: Widgets
+    dependencies:
+      - framework: SwiftUI.framework
+      - framework: WidgetKit.framework
     
 schemes:
   Kiwix:


### PR DESCRIPTION
Compared to the former approach it is solving the following issues:
- we start with a quicker refresh time for the live activity: 2 seconds, whereas if the system locks down the refresh to 10 sec, we have our fallback mechanism, to update both the progress bar to the real value once we can, and keep showing an estimated progress on the bar itself, and in the countdown. The former misalignment in the calculation has been fixed.
- thanks to a deep link solution, tapping on the live activity on the Lock Screen, will take the user to the "Downloads" section of the Kiwix app, where further action can be taken, even if the app was "left" on another screen, before the device was locked.

Note: Further work is needed, to add a direct "pause" / "resume" button, that could control the downloads from the live activity level, without the need to unlock the device.