### PR TITLE
macOS search navigation v2

### DIFF
--- a/Views/SearchResults.swift
+++ b/Views/SearchResults.swift
@@ -134,7 +134,9 @@ struct SearchResults: View {
                         }
                         if nextIndex < viewModel.results.startIndex {
                             $focusedSearchItem.wrappedValue = nil
+                            #if os(macOS)
                             NotificationCenter.default.post(name: .zimSearch, object: nil)
+                            #endif
                         } else if (viewModel.results.startIndex..<viewModel.results.endIndex).contains(nextIndex) {
                             $focusedSearchItem.wrappedValue = viewModel.results[nextIndex].url
                         }

--- a/Views/SearchResults.swift
+++ b/Views/SearchResults.swift
@@ -22,6 +22,7 @@ struct SearchResults: View {
     @Environment(\.dismissSearch) private var dismissSearch
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.managedObjectContext) private var managedObjectContext
+    @Environment(\.isSearching) private var isSearching
     @EnvironmentObject private var viewModel: SearchViewModel
     @EnvironmentObject private var navigation: NavigationViewModel
     @FocusState private var focusedSearchItem: URL? // macOS only
@@ -35,6 +36,17 @@ struct SearchResults: View {
 
     var body: some View {
         Group {
+            #if os(macOS)
+            // Special hidden button to enable down key response when
+            // search is active, to go to search results
+            if isSearching, focusedSearchItem == nil {
+                Button(action: {
+                    focusedSearchItem = viewModel.results.first?.url
+                }, label: {})
+                .hidden()
+                .keyboardShortcut(.downArrow, modifiers: [])
+            }
+            #endif
             if zimFiles.isEmpty {
                 Message(text: LocalString.search_result_zimfile_empty_message)
             } else if horizontalSizeClass == .regular {
@@ -120,7 +132,10 @@ struct SearchResults: View {
                         case .down: nextIndex = viewModel.results.index(after: index)
                         default: nextIndex = viewModel.results.startIndex
                         }
-                        if (viewModel.results.startIndex..<viewModel.results.endIndex).contains(nextIndex) {
+                        if nextIndex < viewModel.results.startIndex {
+                            $focusedSearchItem.wrappedValue = nil
+                            NotificationCenter.default.post(name: .zimSearch, object: nil)
+                        } else if (viewModel.results.startIndex..<viewModel.results.endIndex).contains(nextIndex) {
                             $focusedSearchItem.wrappedValue = viewModel.results[nextIndex].url
                         }
                     }


### PR DESCRIPTION
Fixes: #1090

Adding the capability to move between the search bar and the search results with up/down arrow on macOS.

The ideal would be to do so in other search results as well, eg. on the news / categories or bookmarks section, however those are displaying the results in a grid, and so far finding the displayed items (left/right/up/down) is non trivial in SwiftUI, so will keep this change narrowed down to the ZIM file search results, which is a 1 column list.

The solution is based partially on the ideas presented here: https://github.com/kiwix/kiwix-apple/pull/1079/files

https://github.com/user-attachments/assets/8ba85bf1-d280-4044-b236-a07ed3de5bce

FYA: @jarrodmoldrich
