### PR TITLE
Fix app crash, double check for nil values on URL construction for search results

### DIFF
--- a/SwiftUI/Model/SearchOperation/SearchOperation.mm
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.mm
@@ -35,9 +35,23 @@
     if ([self.absoluteString hasSuffix:@"/"]) {
         return self;
     } else {
-        NSString *lastPath = [self.lastPathComponent stringByAppendingString:@"/"];
-        NSURL* withoutLastPath = [self URLByDeletingLastPathComponent];
-        return [withoutLastPath URLByAppendingPathComponent: lastPath];
+        NSString *lastPathComponent = self.lastPathComponent;
+        if(lastPathComponent == nil) {
+            return self;
+        } else {
+            NSString *lastPath = [lastPathComponent stringByAppendingString:@"/"];
+            NSURL* withoutLastPath = [self URLByDeletingLastPathComponent];
+            if(withoutLastPath == nil) {
+                return self;
+            } else {
+                NSURL *newURL = [withoutLastPath URLByAppendingPathComponent: lastPath];
+                if(newURL == nil) {
+                    return self;
+                } else {
+                    return newURL;
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes: #1161 

The objective-c compiler was not helpful to detect this. On the other hand, the documentation states, that the now checked values can return null, so it's better to check for them, to be on the safe side.