### PR TITLE
Profile and improve performance

### DIFF
--- a/Model/Utilities/Date+Extension.swift
+++ b/Model/Utilities/Date+Extension.swift
@@ -16,14 +16,18 @@
 import Foundation
 
 extension Date {
-
-    /// Format the current date the way as it would come from a server's Last-Modified header
-    /// - Returns: eg: Thu, 16 May 2024 11:38:20 GMT
-    func formatAsGMT() -> String {
+    
+    private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss 'GMT'"
         formatter.locale = Locale(identifier: "en_US")
         formatter.timeZone = TimeZone(abbreviation: "GMT")
-        return formatter.string(from: self)
+        return formatter
+    }()
+
+    /// Format the current date the way as it would come from a server's Last-Modified header
+    /// - Returns: eg: Thu, 16 May 2024 11:38:20 GMT
+    func formatAsGMT() -> String {
+        Self.dateFormatter.string(from: self)
     }
 }

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -114,7 +114,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
     // swiftlint:disable:next function_body_length
     @MainActor private init(tabID: NSManagedObjectID) {
         self.tabID = tabID
-        webView = WKWebView(frame: .zero, configuration: WebViewConfiguration())
+        webView = WKWebView(frame: .zero, configuration: WebViewConfigCache.config)
         if !Bundle.main.isProduction, #available(iOS 16.4, macOS 13.3, *) {
                 webView.isInspectable = true
         }

--- a/Views/BuildingBlocks/WebView.swift
+++ b/Views/BuildingBlocks/WebView.swift
@@ -226,6 +226,10 @@ extension WKWebView {
 }
 #endif
 
+enum WebViewConfigCache {
+    static let config = WebViewConfiguration()
+}
+
 final class WebViewConfiguration: WKWebViewConfiguration {
     override init() {
         super.init()


### PR DESCRIPTION
Things I have found on macOS and iPhone.

Both the date formatter and the web-view configuration object is slow to create and we only really need one of each.

The date formatter is mainly used in ``defaultResponseHeaders`` (video local streaming).

## BEFORE:
<img width="688" alt="Screenshot 2025-04-18 at 22 01 19" src="https://github.com/user-attachments/assets/44a5998e-3331-4aa3-b955-70efb7f1fd7b" />


## AFTER:
<img width="742" alt="Screenshot 2025-04-18 at 22 43 11" src="https://github.com/user-attachments/assets/4124f935-5a9e-452e-9998-e1b8765269db" />


-------

And opening a new browser tab is also improved.
(The first time measured will be longer in both cases, as the configuration and the first browser setup will take more time).

## BEFORE
```
TIMER:: BrowserViewModel.init() took: 0.2607688333373517
TIMER:: BrowserViewModel.init() took: 0.011252750060521066
TIMER:: BrowserViewModel.init() took: 0.011210291646420956
TIMER:: BrowserViewModel.init() took: 0.011013375013135374
```

## AFTER
```
TIMER:: BrowserViewModel.init() took: 0.1968754583504051
TIMER:: BrowserViewModel.init() took: 0.012397083337418735
TIMER:: BrowserViewModel.init() took: 0.005758291692472994
TIMER:: BrowserViewModel.init() took: 0.003947708290070295
TIMER:: BrowserViewModel.init() took: 0.004706125007942319
```

