### PR TITLE
1170 fix outlines and collapsibility

### DIFF
--- a/Model/Entities/Entities.swift
+++ b/Model/Entities/Entities.swift
@@ -91,23 +91,15 @@ final class OutlineItem: ObservableObject, Identifiable {
     let index: Int
     let text: String
     let level: Int
-    let isCollapsible: Bool
     private(set) var children: [OutlineItem]?
 
     @Published var isExpanded = true
-    
-    func asNonCollapsible() -> OutlineItem {
-        let copy = OutlineItem(id: id, index: index, text: text, level: level, isCollapsible: false)
-        copy.children = children
-        return copy
-    }
 
-    init(id: String, index: Int, text: String, level: Int, isCollapsible: Bool = true) {
+    init(id: String, index: Int, text: String, level: Int) {
         self.id = id
         self.index = index
         self.text = text
         self.level = level
-        self.isCollapsible = isCollapsible
     }
 
     convenience init(index: Int, text: String, level: Int) {

--- a/Model/Entities/Entities.swift
+++ b/Model/Entities/Entities.swift
@@ -86,20 +86,28 @@ struct Language: Identifiable, Comparable {
     }
 }
 
-class OutlineItem: ObservableObject, Identifiable {
+final class OutlineItem: ObservableObject, Identifiable {
     let id: String
     let index: Int
     let text: String
     let level: Int
+    let isCollapsible: Bool
     private(set) var children: [OutlineItem]?
 
     @Published var isExpanded = true
+    
+    func asNonCollapsible() -> OutlineItem {
+        let copy = OutlineItem(id: id, index: index, text: text, level: level, isCollapsible: false)
+        copy.children = children
+        return copy
+    }
 
-    init(id: String, index: Int, text: String, level: Int) {
+    init(id: String, index: Int, text: String, level: Int, isCollapsible: Bool = true) {
         self.id = id
         self.index = index
         self.text = text
         self.level = level
+        self.isCollapsible = isCollapsible
     }
 
     convenience init(index: Int, text: String, level: Int) {

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -760,10 +760,9 @@ final class BrowserViewModel: NSObject, ObservableObject,
             }
         }
 
-        // if there is only one h1, flatten one level
+        // if there is only one h1, make the first item non collapsible
         if let rootChildren = root.children, rootChildren.count == 1, let rootFirstChild = rootChildren.first {
-            let children = rootFirstChild.removeAllChildren()
-            self.outlineItemTree = [rootFirstChild] + children
+            self.outlineItemTree = [rootFirstChild.asNonCollapsible()]
         } else {
             self.outlineItemTree = root.children ?? []
         }

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -732,14 +732,12 @@ final class BrowserViewModel: NSObject, ObservableObject,
     @MainActor private func generateOutlineTree(headings: [[String: String]]) {
         let root = OutlineItem(index: -1, text: "", level: 0)
         var stack: [OutlineItem] = [root]
-        var all = [String: OutlineItem]()
 
         headings.enumerated().forEach { index, heading in
             guard let id = heading["id"],
                   let text = heading["text"],
                   let tag = heading["tag"], let level = Int(tag.suffix(1)) else { return }
             let item = OutlineItem(id: id, index: index, text: text, level: level)
-            all[item.id] = item
 
             // get last item in stack
             // if last item is child of item's sibling, unwind stack until a sibling is found
@@ -760,9 +758,9 @@ final class BrowserViewModel: NSObject, ObservableObject,
             }
         }
 
-        // if there is only one h1, make the first item non collapsible
+        // if there is only one item at top level, do not display it only it's children
         if let rootChildren = root.children, rootChildren.count == 1, let rootFirstChild = rootChildren.first {
-            self.outlineItemTree = [rootFirstChild.asNonCollapsible()]
+            self.outlineItemTree = rootFirstChild.children ?? []
         } else {
             self.outlineItemTree = root.children ?? []
         }

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -758,8 +758,11 @@ final class BrowserViewModel: NSObject, ObservableObject,
             }
         }
 
-        // if there is only one item at top level, do not display it only it's children
-        if let rootChildren = root.children, rootChildren.count == 1, let rootFirstChild = rootChildren.first {
+        // if there is only one item at top level, with the same text as the article title
+        // do not display it only it's children
+        if let rootChildren = root.children, rootChildren.count == 1,
+            let rootFirstChild = rootChildren.first,
+           rootFirstChild.text.lowercased() == articleTitle.lowercased() {
             self.outlineItemTree = rootFirstChild.children ?? []
         } else {
             self.outlineItemTree = root.children ?? []

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -114,7 +114,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
     // swiftlint:disable:next function_body_length
     @MainActor private init(tabID: NSManagedObjectID) {
         self.tabID = tabID
-        webView = WKWebView(frame: .zero, configuration: WebViewConfigCache.config)
+        webView = WKWebView(frame: .zero, configuration: WebViewConfiguration())
         if !Bundle.main.isProduction, #available(iOS 16.4, macOS 13.3, *) {
                 webView.isInspectable = true
         }

--- a/Views/BuildingBlocks/WebView.swift
+++ b/Views/BuildingBlocks/WebView.swift
@@ -226,10 +226,6 @@ extension WKWebView {
 }
 #endif
 
-enum WebViewConfigCache {
-    static let config = WebViewConfiguration()
-}
-
 final class WebViewConfiguration: WKWebViewConfiguration {
     override init() {
         super.init()

--- a/Views/Buttons/OutlineButton.swift
+++ b/Views/Buttons/OutlineButton.swift
@@ -19,14 +19,12 @@ struct OutlineButton: View {
     private let items: [OutlineItem]
     private let itemTree: [OutlineItem]
     private let scrollTo: (_ itemID: String) -> Void
-    private let articleTitle: String
     @Environment(\.dismissSearch) private var dismissSearch
     @State private var isShowingOutline = false
     
     init(browser: BrowserViewModel) {
         items = browser.outlineItems
         itemTree = browser.outlineItemTree
-        articleTitle = browser.articleTitle
         scrollTo = { [weak browser] itemID in
             browser?.scrollTo(outlineItemID: itemID)
         }
@@ -69,7 +67,6 @@ struct OutlineButton: View {
                         }.listStyle(.plain)
                     }
                 }
-                .navigationTitle(articleTitle)
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {

--- a/Views/Buttons/OutlineButton.swift
+++ b/Views/Buttons/OutlineButton.swift
@@ -90,7 +90,8 @@ struct OutlineButton: View {
 
         var body: some View {
             if let children = item.children {
-                DisclosureGroup(isExpanded: $item.isExpanded) {
+                let isExpanded = item.isCollapsible ? $item.isExpanded : .constant(true)
+                DisclosureGroup(isExpanded: isExpanded) {
                     ForEach(children) { child in
                         OutlineNode(item: child, action: action)
                     }

--- a/Views/Buttons/OutlineButton.swift
+++ b/Views/Buttons/OutlineButton.swift
@@ -90,8 +90,7 @@ struct OutlineButton: View {
 
         var body: some View {
             if let children = item.children {
-                let isExpanded = item.isCollapsible ? $item.isExpanded : .constant(true)
-                DisclosureGroup(isExpanded: isExpanded) {
+                DisclosureGroup(isExpanded: $item.isExpanded) {
                     ForEach(children) { child in
                         OutlineNode(item: child, action: action)
                     }


### PR DESCRIPTION
Fixes: #1170 

There were 2 issues: 
- the former optimisation broke the Outlines, since the single instance web configuration was setting up the javascript listener, from where we get the outline items via a callback.
- I removed the title from the outline drop down, since it is not clickable, it just makes unnecessary noise (and might do duplication as well)
- If the top level item is a single one, we are removing it, instead of the former solution of flattening the hierarchy:


https://github.com/user-attachments/assets/7c576e22-752b-4e56-b799-945524b5bc09



