### PR TITLE
Remove live activities for release

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -121,10 +121,6 @@ targets:
       - path: Kiwix/SplashScreenKiwix.storyboard
         destinationFilters:
           - iOS
-    dependencies:
-      - target: Widgets
-        destinationFilters:
-          - iOS
   UnitTests:
     type: bundle.unit-test
     supportedDestinations: [iOS, macOS]
@@ -143,19 +139,6 @@ targets:
       - path: Tests
     dependencies:
       - target: Kiwix
-  Widgets:
-    type: app-extension
-    supportedDestinations: [iOS]
-    settings:
-      base:
-        PRODUCT_BUNDLE_IDENTIFIER: self.Kiwix.ioswidgets
-        INFOPLIST_FILE: Widgets/Info.plist
-    sources:
-      - path: Common
-      - path: Widgets
-    dependencies:
-      - framework: SwiftUI.framework
-      - framework: WidgetKit.framework
     
 schemes:
   Kiwix:


### PR DESCRIPTION
It can cause the issue described in: #1169

If the app is crashing / stopping at the background task registered for Live Activities deep-links.