### PR TITLE
1169 openzim navigate to recent tab race fix

### DIFF
--- a/App/App_iOS.swift
+++ b/App/App_iOS.swift
@@ -28,7 +28,6 @@ struct Kiwix: App {
     @StateObject private var navigation = NavigationViewModel()
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     private let fileMonitor: DirectoryMonitor
-//    @State var isOpeningDeeplink = true
     
     init() {
         fileMonitor = DirectoryMonitor(url: URL.documentDirectory) { LibraryOperations.scanDirectory($0) }
@@ -80,7 +79,7 @@ struct Kiwix: App {
                         fileMonitor.start()
                         await LibraryOperations.reopen()
                         if !DeepLinkService.shared.isRunning() {
-                            navigation.navigateToMostRecentTab()                            
+                            navigation.navigateToMostRecentTab()
                         }
                         LibraryOperations.scanDirectory(URL.documentDirectory)
                         LibraryOperations.applyFileBackupSetting()

--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -264,12 +264,14 @@ struct RootView: View {
                 // from opening an external file
                 let browser = BrowserViewModel.getCached(tabID: navigation.currentTabId)
                 browser.forceLoadingState()
-                NotificationCenter.openFiles([url], context: .file)
+                // deeplink id is not needed on macOS
+                NotificationCenter.openFiles([url], context: .file(deepLinkId: nil))
             } else if url.isZIMURL {
                 // from deeplinks
                 let browser = BrowserViewModel.getCached(tabID: navigation.currentTabId)
                 browser.forceLoadingState()
-                NotificationCenter.openURL(url, context: .deepLink)
+                // deeplink id is not needed on macOS
+                NotificationCenter.openURL(url, context: .deepLink(id: nil))
             }
         }
         .onReceive(openURL) { notification in

--- a/App/SplitViewController.swift
+++ b/App/SplitViewController.swift
@@ -89,7 +89,7 @@ final class SplitViewController: UISplitViewController {
         })
         
         openURLObserver = NotificationCenter.default.addObserver(
-            forName: .openURL, object: nil, queue: nil
+            forName: .openURL, object: nil, queue: .main
         ) { [weak self] notification in
             guard let url = notification.userInfo?["url"] as? URL else { return }
             let inNewTab = notification.userInfo?["inNewTab"] as? Bool ?? false
@@ -98,6 +98,10 @@ final class SplitViewController: UISplitViewController {
                     BrowserViewModel.getCached(tabID: tabID).load(url: url)
                 } else if let tabID = self?.navigationViewModel.createTab() {
                     BrowserViewModel.getCached(tabID: tabID).load(url: url)
+                }
+                if let context = notification.userInfo?["context"] as? OpenURLContext,
+                   case .deepLink(let deepLinkId) = context {
+                    DeepLinkService.shared.stopFor(uuid: deepLinkId)
                 }
             }
         }

--- a/App/SplitViewController.swift
+++ b/App/SplitViewController.swift
@@ -107,7 +107,7 @@ final class SplitViewController: UISplitViewController {
                     BrowserViewModel.getCached(tabID: tabID).load(url: url)
                 }
                 if let context = notification.userInfo?["context"] as? OpenURLContext,
-                   case .deepLink(let deepLinkId) = context {
+                   case .deepLink(.some(let deepLinkId)) = context {
                     DeepLinkService.shared.stopFor(uuid: deepLinkId)
                 }
             }

--- a/App/SplitViewController.swift
+++ b/App/SplitViewController.swift
@@ -45,7 +45,6 @@ final class SplitViewController: UISplitViewController {
     }
 
     // MARK: - Lifecycle
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -63,6 +62,13 @@ final class SplitViewController: UISplitViewController {
         setSecondaryController()
 
         // observers
+        observeNavigation()
+        observeOpeningFiles()
+        observeGoBackAndForward()
+        observeAppBackgrounding()
+    }
+    
+    private func observeNavigation() {
         navigationItemObserver = navigationViewModel.$currentItem
             .receive(on: DispatchQueue.main)  // needed to postpones sink after navigationViewModel.currentItem updates
             .dropFirst()
@@ -77,8 +83,7 @@ final class SplitViewController: UISplitViewController {
                     self?.preferredDisplayMode = .automatic
                 }
             }
-        showDownloadsObserver = navigationViewModel
-            .showDownloads
+        showDownloadsObserver = navigationViewModel.showDownloads
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] _ in
                 if self?.traitCollection.horizontalSizeClass == .regular,
@@ -87,7 +92,9 @@ final class SplitViewController: UISplitViewController {
                 }
                 // the compact one is triggered in CompactViewController
         })
-        
+    }
+    
+    private func observeOpeningFiles() {
         openURLObserver = NotificationCenter.default.addObserver(
             forName: .openURL, object: nil, queue: .main
         ) { [weak self] notification in
@@ -105,8 +112,6 @@ final class SplitViewController: UISplitViewController {
                 }
             }
         }
-        observeGoBackAndForward()
-        observeAppBackgrounding()
     }
     
     private func observeGoBackAndForward() {

--- a/Model/DeepLinkService.swift
+++ b/Model/DeepLinkService.swift
@@ -1,0 +1,42 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+
+/// Helper to figure out if a deeplink started ZIM file
+/// handling is already running.
+/// In that case we do not want to handle the default
+/// navigation to the latest opened ZIM file
+@MainActor
+final class DeepLinkService {
+    
+    static let shared = DeepLinkService()
+    
+    private var ids = Set<UUID>()
+    
+    private init() {}
+    
+    func startFor(uuid: UUID) {
+        ids.insert(uuid)
+    }
+    
+    func stopFor(uuid: UUID) {
+        ids.remove(uuid)
+    }
+    
+    func isRunning() -> Bool {
+        !ids.isEmpty
+    }
+}

--- a/SwiftUI/Model/Enum.swift
+++ b/SwiftUI/Model/Enum.swift
@@ -138,14 +138,14 @@ enum ExternalLinkLoadingPolicy: String, CaseIterable, Identifiable, Defaults.Ser
     }
 }
 
-enum OpenURLContext: String {
-    case deepLink
+enum OpenURLContext {
+    case deepLink(id: UUID)
     case file
 }
 
-enum OpenFileContext: String {
+enum OpenFileContext {
     case command
-    case file
+    case file(deepLinkId: UUID? = nil)
     case welcomeScreen
     case library
 }

--- a/SwiftUI/Model/Enum.swift
+++ b/SwiftUI/Model/Enum.swift
@@ -139,7 +139,7 @@ enum ExternalLinkLoadingPolicy: String, CaseIterable, Identifiable, Defaults.Ser
 }
 
 enum OpenURLContext {
-    case deepLink(id: UUID)
+    case deepLink(id: UUID?)
     case file
 }
 

--- a/ViewModel/NavigationViewModel.swift
+++ b/ViewModel/NavigationViewModel.swift
@@ -16,7 +16,6 @@
 import CoreData
 import WebKit
 import Combine
-import os
 
 @MainActor
 final class NavigationViewModel: ObservableObject {
@@ -68,7 +67,6 @@ final class NavigationViewModel: ObservableObject {
         let tab = (try? context.fetch(fetchRequest).first) ?? Self.makeTab(context: context)
         Task {
             await MainActor.run {
-                os_log("open navigate to most recent tab", log: Log.LibraryOperations, type: .error)
                 currentItem = NavigationItem.tab(objectID: tab.objectID)
             }
         }

--- a/ViewModel/NavigationViewModel.swift
+++ b/ViewModel/NavigationViewModel.swift
@@ -16,6 +16,7 @@
 import CoreData
 import WebKit
 import Combine
+import os
 
 @MainActor
 final class NavigationViewModel: ObservableObject {
@@ -67,6 +68,7 @@ final class NavigationViewModel: ObservableObject {
         let tab = (try? context.fetch(fetchRequest).first) ?? Self.makeTab(context: context)
         Task {
             await MainActor.run {
+                os_log("open navigate to most recent tab", log: Log.LibraryOperations, type: .error)
                 currentItem = NavigationItem.tab(objectID: tab.objectID)
             }
         }

--- a/Views/ViewModifiers/FileImport.swift
+++ b/Views/ViewModifiers/FileImport.swift
@@ -83,11 +83,14 @@ struct OpenFileHandler: ViewModifier {
                     for fileID in openedZimFileIDs {
                         guard let url = await ZimFileService.shared.getMainPageURL(zimFileID: fileID) else { return }
                         #if os(macOS)
-                        if .command == context {
+                        switch context {
+                        case .command:
                             NotificationCenter.openURL(url, inNewTab: true)
-                        } else if .file == context {
+                        case .file:
                             // Note: inNewTab:true/false has no meaning here, the system will open a new window anyway
                             NotificationCenter.openURL(url, inNewTab: true, context: .file)
+                        default:
+                            break
                         }
                         #elseif os(iOS)
                         if case .file(.some(let deepLinkID)) = context {

--- a/Views/ViewModifiers/FileImport.swift
+++ b/Views/ViewModifiers/FileImport.swift
@@ -59,7 +59,7 @@ struct OpenFileHandler: ViewModifier {
     enum ActiveAlert {
         case unableToOpen(filenames: [String])
     }
-    // swiftlint:disable:next cyclomatic_complexity
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
     func body(content: Content) -> some View {
         content.onReceive(openFiles) { notification in
             guard let urls = notification.userInfo?["urls"] as? [URL],


### PR DESCRIPTION
Fixes: #1169 

## The problem
The deep-link / opening the app via an external ZIM file is causing one type of navigation, creating a new tab.
When the application is starting, it is trying to find the latest opened tab.
If these 2 things collide in time we have the bug described in #1169. It affects iOS only, as on macOS via the deep-link the system opens a completely new window (which additionally has a different navigation context).

## Solution

- Create a DeepLinkService isolated to the main thread (@MainActor)
- When opening a ZIM file, immediately register it via a unique ID on the DeepLinkService
- Opening the ZIM file goes through a couple of hoops (eg: twice the Notification Center etc.), so we pass down the same unique ID via that route
- Once the tab is open (the deep link handling ends) call the DeepLinkService with this unique id, that it this operation has ended

- In parallel to this (in time), before navigating to the latestOpenedTab, check with the DeepLinkService if we allowed to, as if any unique id is registered (in process) we should not

## Tested on iPad
Out of 20 openings the bug did not occurred.
