### PR TITLE
Fix the donation/support button on iPad

### DIFF
--- a/App/SidebarViewController.swift
+++ b/App/SidebarViewController.swift
@@ -149,7 +149,7 @@ final class SidebarViewController: UICollectionViewController, NSFetchedResultsC
         // show the donation async
         Task {
             if snapshot.sectionIdentifiers.contains(.donation),
-               let _ = await Payment.paymentButtonTypeAsync() {
+               await Payment.paymentButtonTypeAsync() != nil {
                 snapshot.appendItems([.donation], toSection: .donation)
                 await dataSource.apply(snapshot, animatingDifferences: false)
             }

--- a/App/SidebarViewController.swift
+++ b/App/SidebarViewController.swift
@@ -142,11 +142,18 @@ final class SidebarViewController: UICollectionViewController, NSFetchedResultsC
         if snapshot.sectionIdentifiers.contains(.settings) {
             snapshot.appendItems([.settings], toSection: .settings)
         }
-        if snapshot.sectionIdentifiers.contains(.donation) {
-            snapshot.appendItems([.donation], toSection: .donation)
-        }
+        
         dataSource.apply(snapshot, animatingDifferences: false)
         try? fetchedResultController.performFetch()
+        
+        // show the donation async
+        Task {
+            if snapshot.sectionIdentifiers.contains(.donation),
+               let _ = await Payment.paymentButtonTypeAsync() {
+                snapshot.appendItems([.donation], toSection: .donation)
+                await dataSource.apply(snapshot, animatingDifferences: false)
+            }
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Relates to #1184

After investigating this, the current state is, that we should not have support button for custom apps:
https://github.com/kiwix/kiwix-apple/blob/39b1f9d56ef0c2c3bcd6e99b332170f5de509e31/Model/Payment.swift#L126

We do not have the support button in current PhET on macOS and on iPhone, so as of today it is showing up by pure incident on iPad.

It turned out that after the former perf. optimisation + moving the support button to be part of the side menu item, we were no longer calling the function that determines the payment button type, which also checks for things like: is apple pay supported on this device, is it a custom app, and so forth.

So this had to be fixed for the both Kiwix itself, and custom apps as well.

We can treat adding the support button, and "re-branding" it for custom apps as a separate task, if that's what we want.

