### PR TITLE
1179 macos window split screen loading fix

### DIFF
--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -297,27 +297,6 @@ struct RootView: View {
             guard let url = notification.userInfo?["url"] as? URL else {
                 return
             }
-//            switch notification.userInfo?["context"] as? OpenURLContext {
-//            case .file, .deepLink:
-//                // handle the opened ZIM file from Finder / DeepLink
-//                // for which the system opens a new window,
-//                // this part of the code, will be called on all possible windows, we need this though,
-//                // otherwise it won't fire on app start, where we might not have a fully configured window yet.
-//                // We need to filter it down the the last window
-//                // (which is usually not the key window yet at this point),
-//                // and load the content only within that
-//                Task { @MainActor in
-//                    if windowTracker.isLastWindow() {
-//                        BrowserViewModel.getCached(tabID: navigation.currentTabId).load(url: url)
-//                    } else {
-//                        print("coulnd't find the appropriate window for: \(navigation.currentTabId)")
-//                    }
-//                }
-//                return
-//                
-//            case .none:
-//                break
-//            }
             guard controlActiveState == .key else { return }
             let tabID = navigation.currentTabId
             currentNavItem = .tab(objectID: tabID)

--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -274,6 +274,7 @@ struct RootView: View {
                        let mainPageURL = await ZimFileService.shared.getMainPageURL(zimFileID: metadata.fileID) {
                         browser.load(url: mainPageURL)
                     } else {
+                        await browser.clear()
                         isOpenFileAlertPresented = true
                         openFileAlert = .unableToOpen(filenames: [url.lastPathComponent])
                     }

--- a/SwiftUI/Model/Enum.swift
+++ b/SwiftUI/Model/Enum.swift
@@ -140,12 +140,14 @@ enum ExternalLinkLoadingPolicy: String, CaseIterable, Identifiable, Defaults.Ser
 
 enum OpenURLContext {
     case deepLink(id: UUID?)
-    case file
 }
 
 enum OpenFileContext {
-    case command
+    #if os(iOS)
     case file(deepLinkId: UUID? = nil)
+    #else
+    case command
+    #endif
     case welcomeScreen
     case library
 }

--- a/Views/ViewModifiers/FileImport.swift
+++ b/Views/ViewModifiers/FileImport.swift
@@ -78,6 +78,7 @@ struct OpenFileHandler: ViewModifier {
                     }
                 }
                 
+                // action for zim files that can be opened (e.g. open main page)
                 if case .library = context {
                     // don't need to open the main page
                 } else {

--- a/Views/ViewModifiers/FileImport.swift
+++ b/Views/ViewModifiers/FileImport.swift
@@ -49,16 +49,17 @@ struct OpenFileButton<Label: View>: View {
     }
 }
 
+enum OpenFileAlert {
+    case unableToOpen(filenames: [String])
+}
+
 struct OpenFileHandler: ViewModifier {
     @EnvironmentObject private var navigation: NavigationViewModel
     @State private var isAlertPresented = false
-    @State private var activeAlert: ActiveAlert?
+    @State private var activeAlert: OpenFileAlert?
 
     private let openFiles = NotificationCenter.default.publisher(for: .openFiles)
 
-    enum ActiveAlert {
-        case unableToOpen(filenames: [String])
-    }
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     func body(content: Content) -> some View {
         content.onReceive(openFiles) { notification in


### PR DESCRIPTION
Fixes: #1179 

It fixes both opening a deep-link in split screen mode, and also opening a ZIM file in split screen mode.