### PR TITLE
1142 Make random button more accessible

### DIFF
--- a/Views/Commands.swift
+++ b/Views/Commands.swift
@@ -41,6 +41,10 @@ struct NavigationItemKey: FocusedValueKey {
     typealias Value = Binding<NavigationItem?>
 }
 
+struct HasZIMFilesKey: FocusedValueKey {
+    typealias Value = Bool
+}
+
 extension FocusedValues {
     #if os(macOS)
     var browserURL: BrowserURL.Value? {
@@ -48,6 +52,12 @@ extension FocusedValues {
         set { self[BrowserURL.self] = newValue}
     }
     #endif
+    
+    var hasZIMFiles: HasZIMFilesKey.Value? {
+        get { self[HasZIMFilesKey.self] }
+        set { self[HasZIMFilesKey.self] = newValue }
+    }
+    
     var isBrowserURLSet: IsBrowserURLSet.Value? {
         get { self[IsBrowserURLSet.self] }
         set { self[IsBrowserURLSet.self] = newValue }


### PR DESCRIPTION
Fixes: #1142

Apart from re-arranging, had to delegate open settings functionality down the UI layers, while the random functionality up (which is based on the amount of ZIM files loaded, no ZIM files => disabled).

Tested on iPhone.