### PR TITLE
1212 stabilize CI tests, add tab selection UI test (local)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,16 @@ jobs:
 
       - name: Run Unit Tests on macOS
         if: matrix.platform == 'macOS'
-        run: xcodebuild test -scheme Kiwix -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
+        run: xcodebuild clean test -scheme Kiwix -configuration Debug -destination 'platform=macOS'
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v4.2.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Run UI Tests on macOS
+        if: matrix.platform == 'macOS'
+        run: xcodebuild test -scheme UITests_macOS -destination 'platform=macOS'
 
       # - name: Run UI Tests on iPhone
       #   if: matrix.platform == 'iOS'
@@ -87,6 +91,3 @@ jobs:
       #     DEVICE_NAME: "iPad Pro 13-inch (M4)"
       #   run: xcodebuild test -scheme UITests_iPad -destination "platform=iOS Simulator,name=$DEVICE_NAME"
 
-      - name: Run UI Tests on macOS
-        if: matrix.platform == 'macOS'
-        run: xcodebuild test -scheme UITests_macOS -destination 'platform=macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Run Unit Tests on iOS
         if: matrix.platform == 'iOS'
-        run: xcodebuild test -scheme Kiwix -destination 'platform=iOS Simulator,name=iPhone 16 Pro'
+        run: xcodebuild clean test -scheme Kiwix -destination 'platform=iOS Simulator,name=iPhone 16 Pro'
 
       - name: Run Unit Tests on macOS
         if: matrix.platform == 'macOS'
@@ -75,13 +75,17 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Run UI Tests on iPhone
-        if: matrix.platform == 'iOS'
-        run: xcodebuild test -scheme UITests_iPhone -destination 'platform=iOS Simulator,name=iPhone 16 Pro'
+      # - name: Run UI Tests on iPhone
+      #   if: matrix.platform == 'iOS'
+      #   env:
+      #     DEVICE_NAME: "iPhone 16 Pro Max"
+      #   run: xcodebuild test -scheme UITests_iPhone -destination "platform=iOS Simulator,name=$DEVICE_NAME"
 
-      - name: Run UI Tests on iPad
-        if: matrix.platform == 'iOS'
-        run: xcodebuild test -scheme UITests_iPad -destination 'platform=iOS Simulator,name=iPad Pro 13-inch (M4)'
+      # - name: Run UI Tests on iPad
+      #   if: matrix.platform == 'iOS'
+      #   env:
+      #     DEVICE_NAME: "iPad Pro 13-inch (M4)"
+      #   run: xcodebuild test -scheme UITests_iPad -destination "platform=iOS Simulator,name=$DEVICE_NAME"
 
       - name: Run UI Tests on macOS
         if: matrix.platform == 'macOS'

--- a/Model/OPDSParser/OPDSParser.swift
+++ b/Model/OPDSParser/OPDSParser.swift
@@ -15,6 +15,7 @@
 
 protocol Parser {
     var zimFileIDs: Set<UUID> { get }
+    @ZimActor
     func parse(data: Data, urlHost: String) throws
     func getMetaData(id: UUID) -> ZimFileMetaData?
 }
@@ -24,6 +25,7 @@ extension OPDSParser: Parser {
         __getZimFileIDs() as? Set<UUID> ?? Set<UUID>()
     }
 
+    @ZimActor
     func parse(data: Data, urlHost: String) throws {
         if !self.__parseData(data, using: urlHost.removingSuffix("/")) {
             throw LibraryRefreshError.parse

--- a/Tests/LibraryRefreshViewModelTest.swift
+++ b/Tests/LibraryRefreshViewModelTest.swift
@@ -263,7 +263,7 @@ final class LibraryRefreshViewModelTest: XCTestCase {
             case .complete:
                 expectationVMComplete.fulfill()
             default:
-                break;
+                break
             }
         }.store(in: &cancellables)
         await viewModel.start(isUserInitiated: true)

--- a/Tests/LibraryRefreshViewModelTest.swift
+++ b/Tests/LibraryRefreshViewModelTest.swift
@@ -278,7 +278,7 @@ final class LibraryRefreshViewModelTest: XCTestCase {
             case .complete:
                 expectationVMComplete2.fulfill()
             default:
-                break;
+                break
             }
         }.store(in: &cancellables)
         await viewModel.start(isUserInitiated: true)

--- a/Tests/OPDSParserTests.swift
+++ b/Tests/OPDSParserTests.swift
@@ -18,6 +18,7 @@ import XCTest
 
 final class OPDSParserTests: XCTestCase {
     /// Test OPDSParser.parse throws error when OPDS data is invalid.
+    @ZimActor
     func testInvalidOPDSData() {
         XCTExpectFailure("Requires work in dependency to resolve the issue.")
         let content = "Invalid OPDS Data"
@@ -26,6 +27,7 @@ final class OPDSParserTests: XCTestCase {
         )
     }
 
+    @ZimActor
     func testNonCompatibleDataWithUT8() throws {
         let content = "any data"
         let incompatibleEncodings: [String.Encoding] = [.unicode, .utf16, .utf32]
@@ -44,6 +46,7 @@ final class OPDSParserTests: XCTestCase {
     }
 
     /// Test OPDSParser can parse and extract zim file metadata.
+    @ZimActor
     func test() throws {
         let content = """
         <feed xmlns="http://www.w3.org/2005/Atom"

--- a/UITests_iPad/LoadingUI_iPad_Test.swift
+++ b/UITests_iPad/LoadingUI_iPad_Test.swift
@@ -19,19 +19,59 @@ final class LoadingUI_iPad_Test: XCTestCase {
 
     @MainActor
     func testLaunchingApp_on_iPad() throws {
+        let app = XCUIApplication()
+        app.activate()
         
         if !XCUIDevice.shared.orientation.isLandscape {
             XCUIDevice.shared.orientation = .landscapeLeft
         }
         
-        let app = XCUIApplication()
-        app.activate()
-        
-        app.buttons.matching(identifier: "ToggleSidebar").element.tap()
+        if !app.collectionViews["sidebar_collection_view"].exists {
+            app.buttons.matching(identifier: "ToggleSidebar").element.tap()
+        }
         
         let sidebar = app.collectionViews["sidebar_collection_view"]
+        sidebar.cells["categories"].tap()
+        app.buttons["Category, Wikipedia"].tap()
+        app.buttons["Other"].tap()
         
-        XCTAssert(sidebar.cells["New Tab"].isSelected)
+        let zimMini = app.buttons["Apache Pig Docs"].firstMatch
+        Wait.inApp(app, forElement: zimMini)
+        zimMini.tap()
+        
+        let downloadButton = app.buttons["Download"].firstMatch
+        Wait.inApp(app, forElement: downloadButton)
+        downloadButton.tap()
+
+        addUIInterruptionMonitor(withDescription: "\"Kiwix\" Would Like To Send You Notifications") { (alert) -> Bool in
+            let alertButton = alert.buttons["Allow"]
+            if alertButton.exists {
+                alertButton.tap()
+                return true
+            }
+            return false
+        }
+        let openMainPageButton = app.buttons["Open Main Page"]
+        Wait.inApp(app, forElement: openMainPageButton)
+        openMainPageButton.tap()
+        usleep(1)
+        
+        // RESTART THE APP
+        app.terminate()
+        usleep(1)
+        app.activate()
+        
+        testAfterRelaunch(app)
+        
+        app.terminate()
+        
+    }
+    
+    private func testAfterRelaunch(_ app: XCUIApplication) {
+        let sidebar = app.collectionViews["sidebar_collection_view"]
+        let zimFileTab = sidebar.cells["Apache Pig Documentation"].firstMatch
+        Wait.inApp(app, forElement: zimFileTab)
+        XCTAssert(sidebar.cells["Apache Pig Documentation"].firstMatch.isSelected)
         
         sidebar.cells["bookmarks"].tap()
         sidebar.cells["opened"].tap()
@@ -40,5 +80,6 @@ final class LoadingUI_iPad_Test: XCTestCase {
         sidebar.cells["new"].tap()
         sidebar.cells["settings"].tap()
         sidebar.cells["donation"].tap()
+        app.buttons["close_payment_button"].tap()
     }
 }

--- a/ViewModel/LibraryViewModel.swift
+++ b/ViewModel/LibraryViewModel.swift
@@ -131,7 +131,7 @@ final class LibraryViewModel: ObservableObject {
             process.state = .inProgress
 
             // refresh library
-            guard case (var data, let responseURL)? = try await fetchData() else {
+            guard case (let data, let responseURL)? = try await fetchData() else {
                 // this is the case when we have no new data (304 http)
                 // but we still need to refresh the memory only stored
                 // zimfile categories to languages dictionary
@@ -283,19 +283,13 @@ final class LibraryViewModel: ObservableObject {
     }
 
     private func parse(data: Data, urlHost: URL) async throws -> OPDSParser {
-        try await withCheckedThrowingContinuation { continuation in
-            let parser = OPDSParser()
-            do {
-                let urlHostString = urlHost
-                    .withoutQueryParams()
-                    .trim(pathComponents: ["catalog", "v2", "entries"])
-                    .absoluteString
-                try parser.parse(data: data, urlHost: urlHostString)
-                continuation.resume(returning: parser)
-            } catch {
-                continuation.resume(throwing: error)
-            }
-        }
+        let parser = OPDSParser()
+        let urlHostString = urlHost
+            .withoutQueryParams()
+            .trim(pathComponents: ["catalog", "v2", "entries"])
+            .absoluteString
+        try await parser.parse(data: data, urlHost: urlHostString)
+        return parser
     }
 
     private func process(parser: Parser) async throws {

--- a/Views/Library/Library.swift
+++ b/Views/Library/Library.swift
@@ -228,7 +228,7 @@ struct LibraryZimFileContext<Content: View>: View {
                 ZimFileDetail(zimFile: zimFile, dismissParent: dismiss)
             } label: {
                 content
-            }
+            } .accessibilityIdentifier(zimFile.name)
 #endif
         }.contextMenu {
             ZimFileContextMenu(zimFile: zimFile)

--- a/Views/Payment/PaymentForm.swift
+++ b/Views/Payment/PaymentForm.swift
@@ -45,6 +45,7 @@ struct PaymentForm: View {
             Button("", systemImage: "x.circle.fill") {
                 dismiss()
             }
+            .accessibilityIdentifier("close_payment_button")
             .font(.title)
             .foregroundStyle(.tertiary)
             .padding()

--- a/Views/Payment/PaymentResultPopUp.swift
+++ b/Views/Payment/PaymentResultPopUp.swift
@@ -65,6 +65,7 @@ struct PaymentResultPopUp: View {
             Button("", systemImage: "x.circle.fill") {
                 dismiss()
             }
+            .accessibilityIdentifier("close_payment_button")
             .font(.title2)
             .foregroundStyle(.secondary)
             .padding()


### PR DESCRIPTION
Fixes: #1212 

Attempting to stabilize CI unit / UI tests.

After several attempts on GitHub actions, and also on BrowserStack couldn't make the UI tests deterministic enough...

**Proposing to have the UI tests running locally**, where they are stable.
Also added a couple of fixes, that are making the Unit tests more stable on CI.
**I've run them 7 times in a row, and all of them are green:**
https://github.com/kiwix/kiwix-apple/actions/runs/15666712426

Fixes:
- delete the kiwix app before launching the unit tests on the booted simulator
- make sure that the unit tests and the UI tests are running on different simulators
- use valid bundle ids for our test targets
- test targets are limited to the appropriate devices (iPad, iPhone, mac)
- the unit tests around ODPS parser, making sure the DB is clean up before running the test, and that the parsing happens on the same ZimActor (no concurrency conflicts).

UI testing the selection actually works in a way that we navigate to the Catalog, and pick a small ZIM file, that we download, load the main page, restart the app, and then check if the tab is selected.
Double checked the test results, by reverting [the fix made earlier](https://github.com/kiwix/kiwix-apple/pull/1211), and the test fails in that case as expected.
