### PR TITLE
Move support button in iOS settings above the fold

### DIFF
--- a/Views/Settings/Settings.swift
+++ b/Views/Settings/Settings.swift
@@ -166,8 +166,8 @@ struct Settings: View {
                     readingSettings
                     downloadSettings
                     catalogSettings
-                    backupSettings
                     miscellaneous
+                    backupSettings
                 }
                 .modifier(ToolbarRoleBrowser())
                 .navigationTitle(LocalString.settings_navigation_title)


### PR DESCRIPTION
Related to: #1101 

Proposing to move the "Misc" section higher in the Settings on iOS, this way the Support Kiwix button is at least above "the fold":

## BEFORE
![IMG_3240 Medium](https://github.com/user-attachments/assets/b11a9cd4-8ae8-481b-9a8a-0fd3a5bba192)


## AFTER
![IMG_3241 Medium](https://github.com/user-attachments/assets/6a0f7f7f-16fe-4cfc-a180-ff4cad5e18b8)
![Screenshot 2025-06-22 at 16 29 09 Medium](https://github.com/user-attachments/assets/adaf129f-fddb-4d3a-b6e5-b9a80d768372)

It might not fully solve the problem, but should convert better.
