### PR TITLE
Generate Hotspot QR code async

### DIFF
--- a/Model/Utilities/QRCode.swift
+++ b/Model/Utilities/QRCode.swift
@@ -15,13 +15,14 @@
 
 import SwiftUI
 import CoreImage
+import os
 
 struct QRCode {
 
-    static func image(from text: String) -> Image? {
+    static func image(from text: String) async -> Image? {
         let data = Data(text.utf8)
         guard let filter = CIFilter(name: "CIQRCodeGenerator") else {
-            debugPrint("cannot create CIFilter")
+            os_log("QRCode cannot create CIFilter", log: Log.LibraryService, type: .error)
             return nil
         }
         filter.setValue(data, forKey: "inputMessage")
@@ -30,7 +31,7 @@ struct QRCode {
         let transform = CGAffineTransform(scaleX: 20, y: 20)
         guard let outputImage = filter.outputImage?.transformed(by: transform),
               let image = context.createCGImage(outputImage, from: outputImage.extent) else {
-            debugPrint("cannot create qr code image")
+            os_log("QRCode cannot create image", log: Log.LibraryService, type: .error)
             return nil
         }
         return Image(image, scale: 1, label: Text(text))

--- a/Views/Hotspot/HotspotDetails.swift
+++ b/Views/Hotspot/HotspotDetails.swift
@@ -21,6 +21,7 @@ struct HotspotDetails: View {
     let zimFiles: Set<ZimFile>
     @State private var isPresentingUnlinkAlert: Bool = false
     @State private var serverAddress: URL?
+    @State private var qrCodeImage: Image?
     @ObservedObject private var hotspot = Hotspot.shared
     
     private var buttonTitle: String {
@@ -52,10 +53,14 @@ struct HotspotDetails: View {
                 Section(LocalString.hotspot_server_running_title) {
                     AttributeLink(title: LocalString.hotspot_server_running_address,
                                   destination: serverAddress)
-                    if let qrCode = QRCode.image(from: serverAddress.absoluteString) {
-                        qrCode
+                    if let qrCodeImage {
+                        qrCodeImage
                             .resizable()
-                            .frame(width: 250, height: 250, alignment: .trailing)
+                            .frame(width: 250, height: 250)
+                    } else {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            .frame(width: 250, height: 250)
                     }
                 }
                 .collapsible(false)
@@ -72,9 +77,15 @@ struct HotspotDetails: View {
             if isStarted {
                 Task {
                     serverAddress = await hotspot.serverAddress()
+                    if let serverAddress {
+                        qrCodeImage = await QRCode.image(from: serverAddress.absoluteString)
+                    } else {
+                        qrCodeImage = nil
+                    }
                 }
             } else {
                 serverAddress = nil
+                qrCodeImage = nil
             }
         }
     }    


### PR DESCRIPTION
After profiling the applications, it turned out that the QR code generator is slowing things down a bit.
We can move this process to ``async``, to unblock the UI thread,
and add a loading indicator that we can show in the meantime.

![Simulator Screenshot - iPad Pro 13-inch (M4) - 2025-07-07 at 20 56 07 Medium](https://github.com/user-attachments/assets/c24ad3f5-0e60-40b5-abdb-c620ac68ee8c)

<img width="1305" alt="Screenshot 2025-07-07 at 20 48 08" src="https://github.com/user-attachments/assets/8d06229d-1476-42c9-a440-c07e962d6a4c" />
