### PR TITLE
Revert changes on macOS CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Run Unit Tests on macOS
         if: matrix.platform == 'macOS'
-        run: xcodebuild clean test -scheme Kiwix -configuration Debug -destination 'platform=macOS'
+        run: xcodebuild clean test -scheme Kiwix -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v4.2.0


### PR DESCRIPTION
It seems that since I've changed the macOS CI unit test command arguments here:
https://github.com/kiwix/kiwix-apple/commit/1bc6248fe7e16dbc2b871cae85fcfb105d97b0d1
things got worse.

Re-adding the argument: ``CODE_SIGNING_ALLOWED=NO``