### PR TITLE
170 hotspot clean up

### DIFF
--- a/Views/Hotspot/HotspotAddress.swift
+++ b/Views/Hotspot/HotspotAddress.swift
@@ -1,0 +1,40 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import SwiftUI
+
+struct HotspotAddress: View {
+    let serverAddress: URL
+    let qrCodeImage: Image?
+    
+    var body: some View {
+        Section(LocalString.hotspot_server_running_title) {
+            AttributeLink(title: LocalString.hotspot_server_running_address,
+                          destination: serverAddress)
+            if let qrCodeImage {
+                qrCodeImage
+                    .resizable()
+                    .frame(width: 250, height: 250)
+            } else {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .frame(width: 250, height: 250)
+            }
+        }
+#if os(macOS)
+        .collapsible(false)
+#endif
+    }
+}

--- a/Views/Hotspot/HotspotDetails.swift
+++ b/Views/Hotspot/HotspotDetails.swift
@@ -19,7 +19,6 @@ import SwiftUI
 /// Hotspot multi ZIM files side panel
 struct HotspotDetails: View {
     let zimFiles: Set<ZimFile>
-    @State private var isPresentingUnlinkAlert: Bool = false
     @State private var serverAddress: URL?
     @State private var qrCodeImage: Image?
     @ObservedObject private var hotspot = Hotspot.shared

--- a/Views/Hotspot/HotspotDetails.swift
+++ b/Views/Hotspot/HotspotDetails.swift
@@ -18,17 +18,11 @@ import SwiftUI
 #if os(macOS)
 /// Hotspot multi ZIM files side panel
 struct HotspotDetails: View {
-    let zimFiles: Set<ZimFile>
-    @State private var serverAddress: URL?
-    @State private var qrCodeImage: Image?
-    @ObservedObject private var hotspot = Hotspot.shared
-    
-    private var buttonTitle: String {
-        hotspot.isStarted ? LocalString.hotspot_action_stop_server_title : LocalString.hotspot_action_start_server_title
-    }
+    let zimFileIds: Set<UUID>
+    @ObservedObject var hotspot: HotspotObservable
     
     private func zimFilesCount() -> String {
-        Formatter.number.string(from: NSNumber(value: zimFiles.count)) ?? ""
+        Formatter.number.string(from: NSNumber(value: zimFileIds.count)) ?? ""
     }
     
     var body: some View {
@@ -41,52 +35,19 @@ struct HotspotDetails: View {
             }
             .collapsible(false)
             Section(LocalString.zim_file_list_actions_text) {
-                Action(title: buttonTitle) {
-                    await hotspot.toggle()
+                Action(title: hotspot.buttonTitle) {
+                    await hotspot.toggleWith(zimFileIds: zimFileIds)
                 }
                 .buttonStyle(.borderedProminent)
             }
             .collapsible(false)
             
-            if let serverAddress {
-                Section(LocalString.hotspot_server_running_title) {
-                    AttributeLink(title: LocalString.hotspot_server_running_address,
-                                  destination: serverAddress)
-                    if let qrCodeImage {
-                        qrCodeImage
-                            .resizable()
-                            .frame(width: 250, height: 250)
-                    } else {
-                        ProgressView()
-                            .progressViewStyle(.circular)
-                            .frame(width: 250, height: 250)
-                    }
-                }
-                .collapsible(false)
+            if case .started(let address, let qrCodeImage) = hotspot.state {
+                HotspotAddress(serverAddress: address, qrCodeImage: qrCodeImage)
             }
-            Section {
-                Text(LocalString.hotspot_server_explanation)
-                    .font(.subheadline)
-                    .multilineTextAlignment(.leading)
-                    .lineLimit(nil)
-            }.collapsible(false)
+            HotspotExplanation()
         }
         .listStyle(.sidebar)
-        .onReceive(hotspot.$isStarted) { isStarted in
-            if isStarted {
-                Task {
-                    serverAddress = await hotspot.serverAddress()
-                    if let serverAddress {
-                        qrCodeImage = await QRCode.image(from: serverAddress.absoluteString)
-                    } else {
-                        qrCodeImage = nil
-                    }
-                }
-            } else {
-                serverAddress = nil
-                qrCodeImage = nil
-            }
-        }
     }    
 }
 #endif

--- a/Views/Hotspot/HotspotExplanation.swift
+++ b/Views/Hotspot/HotspotExplanation.swift
@@ -1,0 +1,30 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import SwiftUI
+
+struct HotspotExplanation: View {
+    var body: some View {
+        Section {
+            Text(LocalString.hotspot_server_explanation)
+                .font(.subheadline)
+                .multilineTextAlignment(.leading)
+                .lineLimit(nil)
+        }
+#if os(macOS)
+        .collapsible(false)
+#endif
+    }
+}

--- a/Views/Hotspot/HotspotObservable.swift
+++ b/Views/Hotspot/HotspotObservable.swift
@@ -1,0 +1,73 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import SwiftUI
+import Combine
+
+enum HotspotState {
+    @MainActor static let selection = MultiSelectedZimFilesViewModel()
+    
+    case stopped
+    case started(URL, Image?)
+    
+    var isStarted: Bool {
+        switch self {
+        case .stopped: return false
+        case .started: return true
+        }
+    }
+}
+
+@MainActor
+final class HotspotObservable: ObservableObject {
+    
+    @Published var buttonTitle: String = LocalString.hotspot_action_start_server_title
+    @Published var state: HotspotState = .stopped
+    private var hotspot = Hotspot.shared
+    private var cancellables = Set<AnyCancellable>()
+    
+    init() {
+        hotspot.$isStarted.sink { [weak self] isStarted in
+            Task { [weak self] in
+                await self?.update(isStarted: isStarted)
+            }
+        }.store(in: &cancellables)
+    }
+    
+    func toggleWith(zimFileIds: Set<UUID>) async {
+        if hotspot.isStarted {
+            await hotspot.stop()
+        } else {
+            await hotspot.startWith(zimFileIds: zimFileIds)
+        }
+    }
+    
+    private func update(isStarted: Bool) async {
+        if isStarted {
+            buttonTitle = LocalString.hotspot_action_stop_server_title
+            let address = await hotspot.serverAddress()
+            if let address {
+                state = .started(address, nil)
+                let qrCodeImage = await QRCode.image(from: address.absoluteString)
+                state = .started(address, qrCodeImage)
+            } else {
+                state = .stopped
+            }
+        } else {
+            buttonTitle = LocalString.hotspot_action_start_server_title
+            state = .stopped
+        }
+    }
+}


### PR DESCRIPTION
Refactoring, removing duplicates and unused properties.
Creating re-usable views for displaying the address and QR code.
Unifying the code that is responsible for the state of the hotspot, and separating out the ZIM file selection.