### PR TITLE
Use video fixup for black screen only under iOS 18

### DIFF
--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -367,9 +367,11 @@ final class BrowserViewModel: NSObject, ObservableObject,
 
     @MainActor
     func refreshVideoState() {
-        Task { [weak webView] in
-            await MainActor.run { [weak webView] in
-                webView?.evaluateJavaScript("refreshVideoState();")
+        if #unavailable(iOS 18.0) {
+            Task { [weak webView] in
+                await MainActor.run { [weak webView] in
+                    webView?.evaluateJavaScript("refreshVideoState();")
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes: #953 
remove the black screen fix from iOS 18 and above.

From my findings described here:
https://github.com/kiwix/kiwix-apple/issues/953#issuecomment-3146744619

**Summary:**
- we had a black screen issue on iOS 17, that we originally fixed
- this fix came with a side-effect, this was reported in the form of the ticket: #953
- after testing on iOS 18 without the original fix, there is no black screen issue and no side effect
- this PR is removing the original fix from iOS 18 (and above)
- for iOS 17 the original fix is still needed, as we decided that the black screen one is a bigger issue, than the side-effect (when using Picture in Picture).


