### PR TITLE
Hotspot URL not to display port 80

### DIFF
--- a/Model/Hotspot/KiwixHotspot.mm
+++ b/Model/Hotspot/KiwixHotspot.mm
@@ -75,7 +75,16 @@
         return nil;
     }
     NSString *ipAddress = [NSString stringWithUTF8String: self.server->getAddress().addr.c_str()];
-    return [NSString stringWithFormat:@"http://%@:%i", ipAddress, self.server->getPort()];
+    return [NSString stringWithFormat:@"http://%@%@/", ipAddress, [self portNumberSuffix]];
+}
+
+- (NSString *) portNumberSuffix {
+    int portNumber = self.server->getPort();
+    if(portNumber == 80) {
+        return @"";
+    } else {
+        return [NSString stringWithFormat: @":%i", portNumber];
+    }
 }
 
 - (void)stop {


### PR DESCRIPTION
Fixes: #1270 

As you can see below, the trailing slash is also included:

<img width="296" height="640" alt="IMG_3286 Medium" src="https://github.com/user-attachments/assets/59e8864a-a437-474f-a856-fdf6c011d1b1" />
<img width="296" height="640" alt="IMG_3287 Medium" src="https://github.com/user-attachments/assets/3465736e-0486-4373-9147-f1995cfe09e7" />
