### PR TITLE
1275 fix zims not visible on hotspot

### DIFF
--- a/Model/Hotspot/Hotspot.swift
+++ b/Model/Hotspot/Hotspot.swift
@@ -61,9 +61,11 @@ final class Hotspot {
         }
         let portNumber = Int32(port)
         hotspot = KiwixHotspot(__zimFileIds: zimFileIds, onPort: portNumber)
-        await MainActor.run {
-            state = .started
-            preventSleep(true)
+        if hotspot != nil {
+            await MainActor.run {
+                state = .started
+                preventSleep(true)
+            }
         }
     }
     

--- a/Model/Hotspot/KiwixHotspot.h
+++ b/Model/Hotspot/KiwixHotspot.h
@@ -18,7 +18,7 @@
 
 @interface KiwixHotspot : NSObject
 
-- (nonnull KiwixHotspot *)initWithZimFileIds:(NSSet *_Nonnull) zimFileIDs onPort:(int) port NS_REFINED_FOR_SWIFT;
+- (nullable KiwixHotspot *)initWithZimFileIds:(NSSet *_Nonnull) zimFileIDs onPort:(int) port NS_REFINED_FOR_SWIFT;
 - (nullable NSString *) address NS_REFINED_FOR_SWIFT;
 - (void) stop NS_REFINED_FOR_SWIFT;
 

--- a/Model/Hotspot/KiwixHotspot.mm
+++ b/Model/Hotspot/KiwixHotspot.mm
@@ -57,7 +57,7 @@
     
     for (NSUUID *zimFileID in zimFileIDs) {
         try {
-            zim::Archive * _Nullable archive = [[ZimFileService sharedInstance] findArchiveBy:zimFileID];
+            zim::Archive * _Nullable archive = [[ZimFileService sharedInstance] archiveBy: zimFileID];
             if(archive != nullptr) {
                 kiwix::Book book = kiwix::Book();
                 book.update(*archive);

--- a/Model/ZimFileService/ZimFileService.h
+++ b/Model/ZimFileService/ZimFileService.h
@@ -31,6 +31,7 @@
 - (NSUUID *_Nullable)open:(NSUUID *_Nonnull)zimFileID NS_REFINED_FOR_SWIFT;
 - (void)close:(NSUUID *_Nonnull)zimFileID NS_REFINED_FOR_SWIFT;
 - (NSArray *_Nonnull)getReaderIdentifiers NS_REFINED_FOR_SWIFT;
+- (zim::Archive *_Nullable) archiveBy: (NSUUID *_Nonnull) zimFileID;
 - (zim::Archive *_Nullable) findArchiveBy: (NSUUID *_Nonnull) zimFileID;
 - (nonnull void *) getArchives;
 

--- a/Model/ZimFileService/ZimFileService.mm
+++ b/Model/ZimFileService/ZimFileService.mm
@@ -223,6 +223,7 @@
     return [[[zimFileID UUIDString] lowercaseString] cStringUsingEncoding:NSUTF8StringEncoding];
 }
 
+/// Find or insert and return the archive by zimFileID
 - (zim::Archive *_Nullable) archiveBy: (NSUUID *_Nonnull) zimFileID {
     zim::Archive *found = [self findArchiveBy:zimFileID];
     if(found == nil) {
@@ -237,6 +238,7 @@
     }
 }
 
+/// Only find (no insertion of) the archive by zimFileID
 - (zim::Archive *_Nullable) findArchiveBy: (NSUUID *_Nonnull) zimFileID {
     std::string zimFileID_C = [self zimfileID_C: zimFileID];
     auto found = self.archives->find(zimFileID_C);


### PR DESCRIPTION
Fixes: #1275 

It turned out that due to the "lazy" opening of the ZIM files, if it wasn't opened earlier, it would not show up on the Hotspot.

Fixed by using the right function, and documented the difference between the functions for the future.

Also made sure that even in the worst case of not being able to open any of the ZIM files, the Hotspot would not start at all.

