### PR TITLE
Restart Hotspot on application becoming active if needed

### DIFF
--- a/App/App_iOS.swift
+++ b/App/App_iOS.swift
@@ -59,6 +59,9 @@ struct Kiwix: App {
                     case .active:
                         if FeatureFlags.hasLibrary {
                             library.start(isUserInitiated: false)
+                            Task {
+                                await Hotspot.shared.appDidBecomeActive()
+                            }
                         }
                     case .background:
                         break


### PR DESCRIPTION
Fixes: #1272 

Based on the PR: #1282 

It solves the 2nd issue, of restarting the Hotspot Server when the Kiwix iOS App becomes active again, if needed.

I did tested macOS as well in this regard, and the Kiwix Hotspot keeps running even if I lock the screen and turn off the screen (CMD + CTRL + Q) and ESC. Based on that, I don't think we need to do anything extra on macOS.