### PR TITLE
Add detailed download errors

### DIFF
--- a/Model/Downloads/DownloadService.swift
+++ b/Model/Downloads/DownloadService.swift
@@ -72,7 +72,9 @@ final class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegat
             downloadTask.created = Date()
             downloadTask.fileID = zimFileID
             downloadTask.zimFile = zimFile
-            try? context.save()
+            Task { @MainActor in
+                try? context.save()
+            }
 
             if url.lastPathComponent.hasSuffix(".meta4") {
                 url = url.deletingPathExtension()
@@ -129,7 +131,9 @@ final class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegat
             task.resume()
 
             downloadTask.error = nil
-            try? context.save()
+            Task { @MainActor in
+                try? context.save()
+            }
         }
     }
 
@@ -145,7 +149,9 @@ final class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegat
                 let request = DownloadTask.fetchRequest(fileID: zimFileID)
                 guard let downloadTask = try context.fetch(request).first else { return }
                 context.delete(downloadTask)
-                try context.save()
+                Task { @MainActor in
+                    try context.save()
+                }
             } catch {
                 let fileId = zimFileID.uuidString
                 let errorDesc = error.localizedDescription
@@ -234,7 +240,9 @@ final class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegat
                 let request = DownloadTask.fetchRequest(fileID: zimFileID)
                 guard let downloadTask = try? context.fetch(request).first else { return }
                 downloadTask.error = error.localizedDescription
-                try? context.save()
+                Task { @MainActor in
+                    try? context.save()
+                }
             }
         }
         let fileId = zimFileID.uuidString

--- a/Model/Downloads/DownloadService.swift
+++ b/Model/Downloads/DownloadService.swift
@@ -332,7 +332,11 @@ final class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegat
         do {
             try FileManager.default.moveItem(at: location, to: destination)
         } catch {
-            Log.DownloadService.error("Unable to move file from: \(location.path(), privacy: .public) to: \(destination.absoluteString, privacy: .public), due to: \(error.localizedDescription, privacy: .public)")
+            Log.DownloadService.error("""
+Unable to move file from: \(location.path(), privacy: .public) 
+to: \(destination.absoluteString, privacy: .public), 
+due to: \(error.localizedDescription, privacy: .public)
+""")
             showAlert(.downloadError(#line, LocalString.download_service_error_option_unable_to_move_file))
             deleteDownloadTask(zimFileID: zimFileID)
         }

--- a/Model/Downloads/DownloadService.swift
+++ b/Model/Downloads/DownloadService.swift
@@ -313,7 +313,6 @@ final class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegat
         #endif
 
         // move file
-        
         guard let directory = FileManager.default.urls(for: searchPath, in: .userDomainMask).first else {
             Log.DownloadService.fault(
                 "Cannot find download directory! downloadTask: \(taskId, privacy: .public)"
@@ -322,7 +321,7 @@ final class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegat
             deleteDownloadTask(zimFileID: zimFileID)
             return
         }
-        
+
         let fileName = downloadTask.response?.suggestedFilename
             ?? downloadTask.originalRequest?.url?.lastPathComponent
             ?? zimFileID.uuidString + ".zim"

--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "download_service.error.option_directory" = "download directory cannot be found";
 "download_service.error.option_invalid_taskid" = "invalid downloadTask id";
 "download_service.error.option_invalid_response" = "invalid response";
+"download_service.error.option_unable_to_move_file" = "unable to move downloaded file";
 
 "common.dialog.button.open" = "Open";
 "common.dialog.button.open_in_new_tab" = "Open in New Tab";

--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -23,6 +23,10 @@
 "download_service.complete.title" = "Download Completed";
 "download_service.complete.description" = "%@ has been downloaded successfully.";
 "download_service.failed.description" = "Unable to download this file.";
+"download_service.error.description" = "Download failed to succeed. Code: %@, description: %@";
+"download_service.error.option_directory" = "download directory cannot be found";
+"download_service.error.option_invalid_taskid" = "invalid downloadTask id";
+"download_service.error.option_invalid_response" = "invalid response";
 
 "common.dialog.button.open" = "Open";
 "common.dialog.button.open_in_new_tab" = "Open in New Tab";

--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -23,7 +23,7 @@
 "download_service.complete.title" = "Download Completed";
 "download_service.complete.description" = "%@ has been downloaded successfully.";
 "download_service.failed.description" = "Unable to download this file.";
-"download_service.error.description" = "Download failed to succeed. Code: %@, description: %@";
+"download_service.error.description" = "Download failed to succeed. Code: %@\n Description: %@";
 "download_service.error.option_directory" = "download directory cannot be found";
 "download_service.error.option_invalid_taskid" = "invalid downloadTask id";
 "download_service.error.option_invalid_response" = "invalid response";

--- a/Support/qqq.lproj/Localizable.strings
+++ b/Support/qqq.lproj/Localizable.strings
@@ -10,6 +10,10 @@
 "download_service.complete.title" = "Title of the notification a user receives, once the started download completes";
 "download_service.complete.description" = "%@ is a file name.";
 "download_service.failed.description" = "Description of an alert pop up, the user see if an item cannot be downloaded.";
+"download_service.error.description" = "Description of an alert pop up, the user see if an item cannot be downloaded for a specific reason. Includes %@ an error code and %@ additional message as params.";
+"download_service.error.option_directory" = "A description of a specific download error, when the download folder cannot be reached. Becomes part of download_service.error.description";
+"download_service.error.option_invalid_taskid" = "A description of a specific download error, when the download task cannot be identified. Becomes part of download_service.error.description";
+"download_service.error.option_invalid_response" = "A description of a specific download error, when the download response has an invalid type. Becomes part of download_service.error.description";
 "common.dialog.button.open" = "After long pressing a link it is the title of one of the options in the overflow menu";
 "common.dialog.button.open_in_new_tab" = "After long pressing a link it is the title of one of the options in the overflow menu";
 "common.dialog.button.add_bookmark" = "After long pressing the bottom tab menu item it is the title of one of the options in the overflow menu";

--- a/Support/qqq.lproj/Localizable.strings
+++ b/Support/qqq.lproj/Localizable.strings
@@ -14,6 +14,7 @@
 "download_service.error.option_directory" = "A description of a specific download error, when the download folder cannot be reached. Becomes part of download_service.error.description";
 "download_service.error.option_invalid_taskid" = "A description of a specific download error, when the download task cannot be identified. Becomes part of download_service.error.description";
 "download_service.error.option_invalid_response" = "A description of a specific download error, when the download response has an invalid type. Becomes part of download_service.error.description";
+"download_service.error.option_unable_to_move_file" = "A description of a specific download error, when the downloaded file cannot be moved to the right place. Becomes part of download_service.error.description";
 "common.dialog.button.open" = "After long pressing a link it is the title of one of the options in the overflow menu";
 "common.dialog.button.open_in_new_tab" = "After long pressing a link it is the title of one of the options in the overflow menu";
 "common.dialog.button.add_bookmark" = "After long pressing the bottom tab menu item it is the title of one of the options in the overflow menu";

--- a/SwiftUI/Model/Enum.swift
+++ b/SwiftUI/Model/Enum.swift
@@ -18,11 +18,12 @@ import MapKit
 
 import Defaults
 
-enum ActiveAlert: String, Identifiable {
-    var id: String { rawValue }
-
+enum ActiveAlert: Hashable, Identifiable {
+    var id: Int { hashValue }
+    
     case articleFailedToLoad
     case downloadFailed
+    case downloadError(Int, String)
 }
 
 enum ActiveSheet: Hashable, Identifiable {

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -455,7 +455,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
                     NotificationCenter.default.post(
                         name: .alert,
                         object: nil,
-                        userInfo: ["rawValue": ActiveAlert.articleFailedToLoad.rawValue]
+                        userInfo: ["alert": ActiveAlert.articleFailedToLoad]
                     )
                 }
                 return .cancel
@@ -541,7 +541,7 @@ final class BrowserViewModel: NSObject, ObservableObject,
             return
         }
         NotificationCenter.default.post(
-            name: .alert, object: nil, userInfo: ["rawValue": ActiveAlert.articleFailedToLoad.rawValue]
+            name: .alert, object: nil, userInfo: ["alert": ActiveAlert.articleFailedToLoad]
         )
     }
 

--- a/Views/ViewModifiers/AlertHandler.swift
+++ b/Views/ViewModifiers/AlertHandler.swift
@@ -22,8 +22,9 @@ struct AlertHandler: ViewModifier {
 
     func body(content: Content) -> some View {
         content.onReceive(alert) { notification in
-            guard let rawValue = notification.userInfo?["rawValue"] as? String else { return }
-            activeAlert = ActiveAlert(rawValue: rawValue)
+            if let alertValue = notification.userInfo?["alert"] as? ActiveAlert {
+                activeAlert = alertValue
+            }
         }
         .alert(item: $activeAlert) { alert in
             switch alert {
@@ -31,6 +32,8 @@ struct AlertHandler: ViewModifier {
                 return Alert(title: Text(LocalString.alert_handler_alert_failed_title))
             case .downloadFailed:
                 return Alert(title: Text(LocalString.download_service_failed_description))
+            case let .downloadError(code, message):
+                return Alert(title: Text(LocalString.download_service_error_description(withArgs: "\(code)", message)))
             }
         }
     }

--- a/Views/ViewModifiers/AlertHandler.swift
+++ b/Views/ViewModifiers/AlertHandler.swift
@@ -22,19 +22,25 @@ struct AlertHandler: ViewModifier {
 
     func body(content: Content) -> some View {
         content.onReceive(alert) { notification in
-            if let alertValue = notification.userInfo?["alert"] as? ActiveAlert {
-                activeAlert = alertValue
+            guard let rawValue = notification.userInfo?["rawValue"] as? String else { return }
+            activeAlert = nil
+            activeAlert = ActiveAlert(rawValue: rawValue)
+        }
+        .alert(alertText(), isPresented: Binding<Bool>.constant(activeAlert != nil)) {
+            Button(LocalString.common_button_ok) {
+                activeAlert = nil
             }
         }
-        .alert(item: $activeAlert) { alert in
-            switch alert {
-            case .articleFailedToLoad:
-                return Alert(title: Text(LocalString.alert_handler_alert_failed_title))
-            case .downloadFailed:
-                return Alert(title: Text(LocalString.download_service_failed_description))
-            case let .downloadError(code, message):
-                return Alert(title: Text(LocalString.download_service_error_description(withArgs: "\(code)", message)))
-            }
+    }
+        
+    private func alertText() -> String {
+        switch activeAlert {
+        case .articleFailedToLoad:
+            LocalString.alert_handler_alert_failed_title
+        case .downloadFailed:
+            LocalString.download_service_failed_description
+        case nil:
+            ""
         }
     }
 }

--- a/Views/ViewModifiers/AlertHandler.swift
+++ b/Views/ViewModifiers/AlertHandler.swift
@@ -22,9 +22,9 @@ struct AlertHandler: ViewModifier {
 
     func body(content: Content) -> some View {
         content.onReceive(alert) { notification in
-            guard let rawValue = notification.userInfo?["rawValue"] as? String else { return }
-            activeAlert = nil
-            activeAlert = ActiveAlert(rawValue: rawValue)
+            if let alertValue = notification.userInfo?["alert"] as? ActiveAlert {
+                activeAlert = alertValue
+            }
         }
         .alert(alertText(), isPresented: Binding<Bool>.constant(activeAlert != nil)) {
             Button(LocalString.common_button_ok) {
@@ -39,6 +39,8 @@ struct AlertHandler: ViewModifier {
             LocalString.alert_handler_alert_failed_title
         case .downloadFailed:
             LocalString.download_service_failed_description
+        case let .downloadError(code, message):
+            LocalString.download_service_error_description(withArgs: "\(code)", message)
         case nil:
             ""
         }


### PR DESCRIPTION
Fixes: #1308 

We can now display more detailed errors in various points of the download process:

<img width="313" height="256" alt="Screenshot 2025-09-26 at 23 10 47" src="https://github.com/user-attachments/assets/b8de1aa9-6851-48fd-8b66-6100fa8530ba" />
<img width="340" height="269" alt="Screenshot 2025-09-26 at 23 09 29" src="https://github.com/user-attachments/assets/5db9b111-4ad4-4511-bb2e-4d611bd0a336" />
<img width="280" height="242" alt="Screenshot 2025-09-26 at 23 08 28" src="https://github.com/user-attachments/assets/211b4776-5716-45e5-b255-c52ec669854a" />
