### PR TITLE
Place searchfield to the left

### DIFF
--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -129,7 +129,11 @@ struct BrowserTab: View {
         .focusedSceneValue(\.canGoBack, browser.canGoBack)
         .focusedSceneValue(\.canGoForward, browser.canGoForward)
         .modifier(ExternalLinkHandler(externalURL: $browser.externalURL))
-        .searchable(text: $search.searchText, placement: .toolbarPrincipal, prompt: LocalString.common_search)
+        .searchable(
+            text: $search.searchText,
+            placement: searchFieldPlacement(),
+            prompt: LocalString.common_search
+        )
         .onChange(of: scenePhase) { [weak browser] newValue in
             if case .active = newValue {
                 browser?.refreshVideoState()
@@ -154,6 +158,15 @@ struct BrowserTab: View {
             browser?.pauseVideoWhenNotInPIP()
             browser?.persistState()
         }
+    }
+    
+    private func searchFieldPlacement() -> SearchFieldPlacement {
+        #if os(iOS)
+        .toolbarPrincipal
+        #else
+        // on macOS the search suggestions are not showing when the placement is: .toolbarPrincipal
+        .toolbar
+        #endif
     }
 
     private struct Content<LaunchModel>: View where LaunchModel: LaunchProtocol {

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -129,7 +129,7 @@ struct BrowserTab: View {
         .focusedSceneValue(\.canGoBack, browser.canGoBack)
         .focusedSceneValue(\.canGoForward, browser.canGoForward)
         .modifier(ExternalLinkHandler(externalURL: $browser.externalURL))
-        .searchable(text: $search.searchText, placement: .toolbar, prompt: LocalString.common_search)
+        .searchable(text: $search.searchText, placement: .toolbarPrincipal, prompt: LocalString.common_search)
         .onChange(of: scenePhase) { [weak browser] newValue in
             if case .active = newValue {
                 browser?.refreshVideoState()


### PR DESCRIPTION
Fixes #1317 

# iPad
<img width="640" height="480" alt="Simulator Screenshot - iPad Air 13-inch (iOS 26) - 2025-10-04 at 00 47 02 Medium" src="https://github.com/user-attachments/assets/718eff5b-072c-45cb-8491-345bad104533" />

# macOS
It can be placed to the left, but it won't work for us, as search suggestions are not showing up in this case. Probably a SwiftUI bug.

# iPhone
not applicable: the search-bar is already in the middle of the screen in both landscape and portrait