### PR TITLE
Fix empty search side panel for custom apps

### DIFF
--- a/Views/SearchResults.swift
+++ b/Views/SearchResults.swift
@@ -148,7 +148,7 @@ struct SearchResults: View {
 
     var sidebar: some View {
         List {
-            if !recentSearchTexts.isEmpty {
+            if !FeatureFlags.hasLibrary || !recentSearchTexts.isEmpty {
                 Section {
                     ForEach(recentSearchTexts.prefix(6), id: \.self) { searchText in
                         Button(searchText) {
@@ -192,6 +192,7 @@ struct SearchResults: View {
             } label: {
                 Text(LocalString.search_result_button_clear).font(.caption).fontWeight(.medium)
             }
+            .disabled(recentSearchTexts.isEmpty)
         }
     }
 


### PR DESCRIPTION
Fixes: #1320 

This was a custom app specific issue. For Kiwix we always have the search side bar in a useful state, since we display the local ZIM files to include in the search.

After the changes it makes more sense now:

<img width="640" height="480" alt="Simulator Screenshot - iPad Air 13-inch (iOS 26) - 2025-10-05 at 17 25 52 Medium" src="https://github.com/user-attachments/assets/42885f91-66f3-42b9-a1f6-34501e0e0fe0" />
<img width="640" height="480" alt="Simulator Screenshot - iPad Air 13-inch (iOS 26) - 2025-10-05 at 17 26 02 Medium" src="https://github.com/user-attachments/assets/378ef294-ef1d-44cc-a029-f14f17541f31" />
<img width="640" height="480" alt="Simulator Screenshot - iPad Air 13-inch (iOS 26) - 2025-10-05 at 17 22 39 Medium" src="https://github.com/user-attachments/assets/cb04ae78-39c4-4eee-ab78-cba61cf68ab9" />
