### PR TITLE
Hide orphaned bookmarks on New Tab

### DIFF
--- a/Views/LocalLibraryList.swift
+++ b/Views/LocalLibraryList.swift
@@ -22,6 +22,7 @@ struct LocalLibraryList: View {
     private let load: (URL) -> Void
     @FetchRequest(
         sortDescriptors: [NSSortDescriptor(keyPath: \Bookmark.created, ascending: false)],
+        predicate: NSPredicate(format: "zimFile.isMissing == false"),
         animation: .easeInOut
     ) private var bookmarks: FetchedResults<Bookmark>
     @FetchRequest(


### PR DESCRIPTION
#### Fixes:
#1667

## Impact for end user
Hides bookmarks for deleted books on the New Tab page, making it perfectly consistent with the main Bookmarks view.

## Description
- Changed: `Views/LocalLibraryList.swift`
- Added: Filter for `zimFile.isMissing == false`

## Screenshots
N/A

### Tested on
- [x] **iPhone**
- [x] **iPad**
- [x] **mac**
