### PR TITLE
Fix CI for external PRs

### DIFF
--- a/.github/actions/xcbuild/action.yml
+++ b/.github/actions/xcbuild/action.yml
@@ -70,6 +70,7 @@ runs:
         security unlock-keychain -p $KEYCHAIN_PASSWORD $KEYCHAIN
 
     - name: Add Apple Development certificate to Keychain
+      if: ${{ inputs.APPLE_DEVELOPMENT_SIGNING_CERTIFICATE != '' }}
       uses: ./.github/actions/install-cert
       with:
         SIGNING_CERTIFICATE: ${{ inputs.APPLE_DEVELOPMENT_SIGNING_CERTIFICATE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
     env:
       EXTRA_XCODEBUILD: ""
       APPLE_STORE_AUTH_KEY_PATH: /tmp/authkey.p8
-      APPLE_AUTH_PARAMS: "-authenticationKeyPath /tmp/authkey.p8 -authenticationKeyID ${{ secrets.APPLE_STORE_AUTH_KEY_ID }} -authenticationKeyIssuerID ${{ secrets.APPLE_STORE_AUTH_KEY_ISSUER_ID }}"
     strategy:
       fail-fast: false
       matrix:
@@ -38,21 +37,28 @@ jobs:
         run: python localizations.py validate
 
       - name: Add Apple Store Key
+        if: ${{ secrets.APPLE_STORE_AUTH_KEY != '' }}
         run: echo "${{ secrets.APPLE_STORE_AUTH_KEY }}" | base64 --decode -o ${{ env.APPLE_STORE_AUTH_KEY_PATH}}
 
       - name: Set EXTRA_XCODEBUILD for iOS
         if: matrix.platform == 'iOS'
-        run: echo "EXTRA_XCODEBUILD=-sdk iphoneos26.4 ${{ env.APPLE_AUTH_PARAMS }}" >> $GITHUB_ENV
+        run: |
+          if [ -n "${{ secrets.APPLE_STORE_AUTH_KEY_ID }}" ]; then
+            echo "EXTRA_XCODEBUILD=-sdk iphoneos26.4 -authenticationKeyPath ${{ env.APPLE_STORE_AUTH_KEY_PATH }} -authenticationKeyID ${{ secrets.APPLE_STORE_AUTH_KEY_ID }} -authenticationKeyIssuerID ${{ secrets.APPLE_STORE_AUTH_KEY_ISSUER_ID }}" >> $GITHUB_ENV
+          else
+            echo "EXTRA_XCODEBUILD=-sdk iphoneos26.4" >> $GITHUB_ENV
+          fi
 
       - name: Set EXTRA_XCODEBUILD for macOS
         if: matrix.platform == 'macOS'
-        run: echo "EXTRA_XCODEBUILD=${{ env.APPLE_AUTH_PARAMS }}" >> $GITHUB_ENV
+        run: |
+          if [ -n "${{ secrets.APPLE_STORE_AUTH_KEY_ID }}" ]; then
+            echo "EXTRA_XCODEBUILD=-authenticationKeyPath ${{ env.APPLE_STORE_AUTH_KEY_PATH }} -authenticationKeyID ${{ secrets.APPLE_STORE_AUTH_KEY_ID }} -authenticationKeyIssuerID ${{ secrets.APPLE_STORE_AUTH_KEY_ISSUER_ID }}" >> $GITHUB_ENV
+          fi
 
       - name: Disable code signing for external PRs
-        if: env.APPLE_DEVELOPMENT_SIGNING_CERTIFICATE == ''
+        if: ${{ secrets.APPLE_DEVELOPMENT_SIGNING_CERTIFICATE == '' }}
         run: echo "EXTRA_XCODEBUILD=${EXTRA_XCODEBUILD} CODE_SIGNING_ALLOWED=NO" >> $GITHUB_ENV
-        env:
-          APPLE_DEVELOPMENT_SIGNING_CERTIFICATE: ${{ secrets.APPLE_DEVELOPMENT_SIGNING_CERTIFICATE }}
 
       - name: Remove in-app-payments capability for unit tests on macOS
         if: matrix.platform == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
         if: matrix.platform == 'macOS'
         run: echo "EXTRA_XCODEBUILD=${{ env.APPLE_AUTH_PARAMS }}" >> $GITHUB_ENV
 
+      - name: Disable code signing for external PRs
+        if: env.APPLE_DEVELOPMENT_SIGNING_CERTIFICATE == ''
+        run: echo "EXTRA_XCODEBUILD=${EXTRA_XCODEBUILD} CODE_SIGNING_ALLOWED=NO" >> $GITHUB_ENV
+        env:
+          APPLE_DEVELOPMENT_SIGNING_CERTIFICATE: ${{ secrets.APPLE_DEVELOPMENT_SIGNING_CERTIFICATE }}
+
       - name: Remove in-app-payments capability for unit tests on macOS
         if: matrix.platform == 'macOS'
         run: |


### PR DESCRIPTION
#### Fixes: 
Fixes #1677

## Impact for end user
None for app users. This fixes the CI pipeline for open-source contributors, allowing tests to run successfully on external forks without failing on missing Apple Developer certificates.

## Description

- Changed: Updated `.github/actions/xcbuild/action.yml` to skip the `install-cert` step if the certificate secret is missing.
- Added: Added a step in `.github/workflows/ci.yml` that appends `CODE_SIGNING_ALLOWED=NO` to the Xcode build command for external PRs.
- Removed: 

## Screenshots
N/A (CI configuration changes only)

### Tested on
- [ ] **iPhone**
- [ ] **iPad**
- [x] **mac** *(via GitHub Actions macOS runners)*
