### PR TITLE
Support JS document.cookies

### DIFF
--- a/Model/Utilities/Log.swift
+++ b/Model/Utilities/Log.swift
@@ -22,6 +22,7 @@ struct Log {
     static let LibraryOperations = Logger(subsystem: subsystem, category: "LibraryOperations")
     static let QRCode = Logger(subsystem: subsystem, category: "QRCode")
     static let OPDS = Logger(subsystem: subsystem, category: "OPDS")
+    static let Cookies = Logger(subsystem: subsystem, category: "Cookies")
     static let URLSchemeHandler = Logger(subsystem: subsystem, category: "URLSchemeHandler")
     static let Branding = Logger(subsystem: subsystem, category: "Branding")
     static let Payment = Logger(subsystem: subsystem, category: "Payment")

--- a/Model/WebViewConfig/Cookies/CookieStore.swift
+++ b/Model/WebViewConfig/Cookies/CookieStore.swift
@@ -17,5 +17,5 @@ import Foundation
 
 enum CookieStore {
     @MainActor
-    static let shared = ZimCookieStore(persistance: CookiePersistenceInDefaults())
+    static let shared = ZimCookieStore(persistence: CookiePersistenceInDefaults())
 }

--- a/Model/WebViewConfig/Cookies/CookieStore.swift
+++ b/Model/WebViewConfig/Cookies/CookieStore.swift
@@ -1,0 +1,21 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+
+enum CookieStore {
+    @MainActor
+    static let shared = ZimCookieStore(persistance: CookiePersistenceInDefaults())
+}

--- a/Model/WebViewConfig/Cookies/ZimCookiePersistence.swift
+++ b/Model/WebViewConfig/Cookies/ZimCookiePersistence.swift
@@ -1,0 +1,40 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Defaults
+import Foundation
+
+@MainActor protocol ZIMCookiePersistence {
+    func load() -> [UUID: String]
+    func save(_ values: [UUID: String])
+}
+
+@MainActor
+final class CookiePersistenceInDefaults: ZIMCookiePersistence {
+    func load() -> [UUID: String] {
+        let storedValues: [String: String] = Defaults[.cookieStore]
+        return storedValues.reduce(into: .init(), { partialResult, zimFileIdCookies in
+            if let zimFileId = UUID(uuidString: zimFileIdCookies.key) {
+                partialResult.updateValue(zimFileIdCookies.value, forKey: zimFileId)
+            }
+        })
+    }
+    func save(_ values: [UUID: String]) {
+        let storedValues: [String: String] = values.reduce(into: [:]) { nextPartialResult, zimFileIDValue in
+            nextPartialResult.updateValue(zimFileIDValue.value, forKey: zimFileIDValue.key.uuidString)
+        }
+        Defaults[.cookieStore] = storedValues
+    }
+}

--- a/Model/WebViewConfig/Cookies/ZimCookieStore.swift
+++ b/Model/WebViewConfig/Cookies/ZimCookieStore.swift
@@ -37,11 +37,11 @@ final class ZimCookieStore {
     ///   - zimFileID: the associated content
     ///   - cookie: the JSON encoded cookie values
     func save(zimFileID: UUID, cookies jsonValues: String) {
-        Log.Cookies.debug("\(#function): \(jsonValues)")
-        guard !jsonValues.isEmpty else {
+        guard !jsonValues.isEmpty, jsonValues != "[]" else {
             deleteAllFor(zimFileID: zimFileID)
             return
         }
+        Log.Cookies.debug("\(#function): \(jsonValues)")
         store[zimFileID] = jsonValues
         saveStore()
     }

--- a/Model/WebViewConfig/Cookies/ZimCookieStore.swift
+++ b/Model/WebViewConfig/Cookies/ZimCookieStore.swift
@@ -1,0 +1,59 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Defaults
+import Foundation
+
+@MainActor
+final class ZimCookieStore {
+    
+    private let persistance: ZIMCookiePersistence
+    private var store: [UUID: String]
+    
+    init(persistance: ZIMCookiePersistence) {
+        self.persistance = persistance
+        store = persistance.load()
+    }
+    
+    /// Return the whole cookie store for a given ZIM file
+    /// it's a JSON encoded string
+    func getAllFor(zimFileID: UUID) -> String? {
+        store[zimFileID]
+    }
+    
+    /// - Parameters:
+    ///   - zimFileID: the associated content
+    ///   - cookie: the JSON encoded cookie values
+    func save(zimFileID: UUID, cookies jsonValues: String) {
+        Log.Cookies.debug("\(#function): \(jsonValues)")
+        guard !jsonValues.isEmpty else {
+            deleteAllFor(zimFileID: zimFileID)
+            return
+        }
+        store[zimFileID] = jsonValues
+        saveStore()
+    }
+    
+    func deleteAllFor(zimFileID: UUID) {
+        store[zimFileID] = nil
+        Log.Cookies.debug("delete all cookies for zimFileID: \(zimFileID)")
+        saveStore()
+    }
+    
+    /// saving the whole store itself on changes
+    private func saveStore() {
+        persistance.save(store)
+    }
+}

--- a/Model/WebViewConfig/Cookies/ZimCookieStore.swift
+++ b/Model/WebViewConfig/Cookies/ZimCookieStore.swift
@@ -19,12 +19,12 @@ import Foundation
 @MainActor
 final class ZimCookieStore {
     
-    private let persistance: ZIMCookiePersistence
+    private let persistence: ZIMCookiePersistence
     private var store: [UUID: String]
     
-    init(persistance: ZIMCookiePersistence) {
-        self.persistance = persistance
-        store = persistance.load()
+    init(persistence: ZIMCookiePersistence) {
+        self.persistence = persistence
+        store = persistence.load()
     }
     
     /// Return the whole cookie store for a given ZIM file
@@ -54,6 +54,6 @@ final class ZimCookieStore {
     
     /// saving the whole store itself on changes
     private func saveStore() {
-        persistance.save(store)
+        persistence.save(store)
     }
 }

--- a/Model/WebViewConfig/WebViewConfiguration.swift
+++ b/Model/WebViewConfig/WebViewConfiguration.swift
@@ -43,6 +43,17 @@ final class WebViewConfiguration: WKWebViewConfiguration {
                     controller.addUserScript(script)
                 }
             }
+            
+            if let url = Bundle.main.url(forResource: "zimCookies", withExtension: "js"),
+               let javascript = try? String(contentsOf: url) {
+                let script = WKUserScript(
+                    source: javascript,
+                    injectionTime: .atDocumentStart,
+                    forMainFrameOnly: false
+                )
+                controller.addUserScript(script)
+            }
+            
             return controller
         }()
     }

--- a/Support/zimCookieTests/cookie_tests.js
+++ b/Support/zimCookieTests/cookie_tests.js
@@ -1,0 +1,113 @@
+it("sets up the cookie store with empty value", () => {
+  const store = new ZimCookieStore();
+  store.load("[]");
+  return assertEqual(store.cookies(), "");
+});
+
+it("sets up the cookie store with json values", () => {
+  const store = new ZimCookieStore();
+  store.load(
+    '[["name",{"value":"Kiwix Tester","expiryDate":null}],["_pk_id",{"value":"b40=a8","expiryDate":"2027-09-05T19:14:17.000Z"}],["theme",{"value":"dark","expiryDate":"2027-08-14T09:00:00.000Z"}]]',
+  );
+  return assertEqual(
+    store.cookies(),
+    "name=Kiwix Tester; _pk_id=b40=a8; theme=dark",
+  );
+});
+
+it("stores a cookie with a value", () => {
+  const store = new ZimCookieStore();
+  const testCookie = "myKey=value;";
+  store.save(testCookie);
+  document.cookie = testCookie;
+  return assertEqual(store.cookies(), document.cookie);
+});
+
+it("stores an empty value cookie", () => {
+  const store = new ZimCookieStore();
+  const testCookie = "myKey=;";
+  store.save(testCookie);
+  document.cookie = testCookie;
+  return assertEqual(store.cookies(), document.cookie);
+});
+
+it("removes a cookie, using max-age = 0", () => {
+  const store = new ZimCookieStore();
+  const testCookie1 = "myKey=oldValue;";
+  const testCookie2 = "myKey=oldValue; max-age=0;";
+  store.save(testCookie1);
+  store.save(testCookie2);
+  document.cookie = testCookie1;
+  document.cookie = testCookie2;
+  return assertEqual(store.cookies(), document.cookie);
+});
+
+it("won't store expired values", () => {
+  const store = new ZimCookieStore();
+  store.save(
+    "my_key=some_value; Expires=Sun, 05 Sep 2027 19:14:00 GMT;",
+    new Date("Sun, 05 Sep 2027 19:14:01 GMT"), // we are a second later already
+  );
+  return assertEqual(store.cookies(), "");
+});
+
+it("will return the same as document.cookie for multiple values", () => {
+  const store = new ZimCookieStore();
+  const cookiesToSet = [
+    "name=Kiwix Tester;max-age=300",
+    "_pk_id=b40=a; Expires=Sun, 05 Sep 2157 19:14:17 GMT;SameSite=Lax",
+    "theme=dark;;max-age=31536000",
+  ];
+  cookiesToSet.forEach((cookie) => {
+    store.save(cookie);
+    document.cookie = cookie;
+  });
+  const valueToPersist = store.valueToPersist();
+  const newStore = new ZimCookieStore();
+  newStore.load(valueToPersist);
+
+  const stored = newStore
+    .cookies()
+    .split(";")
+    .map((x) => {
+      return x.trim();
+    })
+    .sort();
+  const documented = document.cookie
+    .split(";")
+    .map((x) => {
+      return x.trim();
+    })
+    .sort();
+
+  return assertEqual(stored, documented);
+});
+
+it("will set the expiry date correctly", () => {
+  cleanUp();
+
+  const store = new ZimCookieStore();
+  const now = new Date();
+  const cookie = "name=Joe Tester; max-age=31536000";
+  store.save(cookie);
+  document.cookie = cookie;
+  return assertEqual(store.cookies(now), document.cookie);
+});
+
+it("won't persist session only items (entries with a null expiry date)", () => {
+  const store = new ZimCookieStore();
+  store.save("the_key=is session only;");
+  return assertEqual(store.valueToPersist(), "[]");
+});
+
+function cleanUp() {
+  document.cookie.split(";").forEach((cookie) => {
+    const cookieName = cookie.split("=")[0].trim();
+    // Set cookie max-age to 0 date delete it
+    document.cookie = `${cookieName}=; max-age=0;`;
+  });
+}
+it("clean up", () => {
+  cleanUp();
+  return assertEqual(document.cookie, "");
+});

--- a/Support/zimCookieTests/cookie_tests.js
+++ b/Support/zimCookieTests/cookie_tests.js
@@ -15,6 +15,12 @@ it("sets up the cookie store with json values", () => {
   );
 });
 
+it("handles invalid load data gracefully", () => {
+  const store = new ZimCookieStore();
+  store.load('invalid_data');
+  return assertEqual(store.cookies(), "");
+});
+
 it("stores a cookie with a value", () => {
   const store = new ZimCookieStore();
   const testCookie = "myKey=value;";

--- a/Support/zimCookieTests/index.html
+++ b/Support/zimCookieTests/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Unit testing</title>
+  <script src="test_framework.js"></script>
+  <script src="../zimCookies.js"></script>
+  <script defer src="cookie_tests.js"></script>
+  <style>
+    .test_result { margin: 0; }
+    .success { color: green; }
+    .failure { color: red; }
+    .success::before { content: '✔ '; }
+    .failure::before { content: '✘ '; }
+  </style>
+</head>
+<body></body>
+</html>

--- a/Support/zimCookieTests/test_framework.js
+++ b/Support/zimCookieTests/test_framework.js
@@ -1,0 +1,31 @@
+/**
+ * Based on: https://alexwlchan.net/2023/testing-javascript-without-a-framework/
+ * CC by 4.0 https://creativecommons.org/licenses/by/4.0/
+ */
+function it(description, body_of_test) {
+  const result = document.createElement("p");
+  result.classList.add("test_result");
+  let testResult = body_of_test();
+  if (testResult === true) {
+    result.classList.add("success");
+    result.innerHTML = description;
+  } else {
+    result.classList.add("failure");
+    result.innerHTML = `${description}<br/><pre>${testResult}</pre>`;
+  }
+  document.body.appendChild(result);
+}
+
+function assertEqual(x, y) {
+  if (
+    x === y ||
+    (typeof x === "object" &&
+      typeof y === "object" &&
+      x.length === y.length &&
+      x.every((element, index) => element === y[index]))
+  ) {
+    return true;
+  } else {
+    return `${x} != ${y}`;
+  }
+}

--- a/Support/zimCookies.js
+++ b/Support/zimCookies.js
@@ -93,7 +93,12 @@ class ZimCookieStore {
   }
 
   load(values) {
-    this.store = new Map(JSON.parse(values));
+    try {
+      this.store = new Map(JSON.parse(values));
+    } catch (e) {
+      console.warn('Invalid ZIM cookies payload, resetting store:', e);
+      this.store = new Map();
+    }
   }
 }
 

--- a/Support/zimCookies.js
+++ b/Support/zimCookies.js
@@ -1,0 +1,139 @@
+// go around Wombat.js overriding Date.now()
+function currentDate() {
+  if(typeof(__wb_Date_now) == "function") {
+    return new Date(__wb_Date_now());
+  }
+  return new Date();
+}
+
+class ZimCookieStore {
+  constructor() {
+    this.store = new Map();
+  }
+
+  cookies(now = currentDate()) {
+    var parts = new Array();
+    for (const [key, valueAndDate] of this.store.entries()) {
+      const { expiryDate: expDate } = valueAndDate;
+      if (expDate != null && expDate <= now) {
+        continue;
+      } else {
+        const { value: cookieValue } = valueAndDate;
+        parts.push([key, cookieValue].join("="));
+      }
+    }
+    return parts.join("; ");
+  }
+
+  save(cookie, now = currentDate()) {
+    const [keyValue, ...attributes] = String(cookie).split(";");
+    const [rawKey, ...rawVal] = String(keyValue ?? "").split("=");
+    const key = (rawKey ?? "").trim();
+    const value = rawVal.join("=").trim();
+    if (!key) {
+      console.warn("invalid cookie key:", key);
+      return;
+    }
+
+    const attrMap = new Map(
+      attributes
+        .map((s) => String(s).trim())
+        .filter(Boolean)
+        .map((s) => {
+          const [k, ...v] = s.split("=");
+          return [String(k).trim().toLowerCase(), v.join("=").trim()];
+        }),
+    );
+    const maxAge = attrMap.get("max-age");
+    const expires = attrMap.get("expires");
+    if (maxAge !== undefined) {
+      const maxAgeNumber = Number(maxAge);
+      if (Number.isFinite(maxAgeNumber)) {
+        if (maxAgeNumber <= 0) {
+          this.store.delete(key);
+          return;
+        } else {
+          const expiry = new Date(now.getTime() + maxAgeNumber * 1000);
+          this.store.set(key, {
+            value: value,
+            expiryDate: expiry,
+          });
+          return;
+        }
+      }
+    } else if (expires !== undefined) {
+      const expiryDate = new Date(expires);
+      if (!isNaN(expiryDate)) {
+        if (now < expiryDate) {
+          this.store.set(key, {
+            value: value,
+            expiryDate: expiryDate,
+          });
+          return;
+        } else {
+          this.store.delete(key);
+          return;
+        }
+      }
+    }
+    // store in session only, without a specific date:
+    this.store.set(key, { value: value, expiryDate: null });
+  }
+
+  valueToPersist() {
+    const entries = Array.from(this.store).filter((entry) => {
+      return entry[1].expiryDate != null;
+    });
+    return JSON.stringify(entries);
+  }
+
+  persist() {
+    const zimCookies = window.webkit?.messageHandlers?.zimCookies;
+    zimCookies?.postMessage(this.valueToPersist());
+  }
+
+  load(values) {
+    this.store = new Map(JSON.parse(values));
+  }
+}
+
+// SHIM
+var __zimCookieStore = new ZimCookieStore();
+
+// save the cookies on native side
+function getZIMCookies() {
+  __zimCookieStore.persist();
+}
+
+// injecting cookies from native side here, it should be JSON encoded
+function setZIMCookies(newValue) {
+  __zimCookieStore.load(newValue);
+}
+
+(function () {
+  // 1. Get the original native setter from the Prototype
+  const cookieDescriptor =
+    Object.getOwnPropertyDescriptor(Document.prototype, "cookie") ||
+    Object.getOwnPropertyDescriptor(HTMLDocument.prototype, "cookie");
+
+  if (!cookieDescriptor) {
+    console.error("Could not find cookie descriptor.");
+    return;
+  }
+
+  // 2. Redefine the property with custom hooks
+  Object.defineProperty(Document.prototype, "cookie", {
+    configurable: true,
+    enumerable: true,
+
+    get: function () {
+      return __zimCookieStore.cookies();
+    },
+
+    // Intercept updates
+    set: function (newValue) {
+      __zimCookieStore.save(newValue);
+      __zimCookieStore.persist();
+    },
+  });
+})();

--- a/SwiftUI/Model/DefaultKeys.swift
+++ b/SwiftUI/Model/DefaultKeys.swift
@@ -55,6 +55,8 @@ extension Defaults.Keys {
     static let selectedHotspotIds = Key<Set<UUID>>("slectedHotspotIds", default: Set<UUID>())
     static let openZIMsShowBy = Key<ZIMsShowBy>("openZIMsShowBy", default: ZIMsShowBy.all)
     static let opneZIMsSorting = Key<ZIMsSortBy>("openZIMsSortBy", default: ZIMsSortBy.size(.forward))
+    
+    static let cookieStore = Key<[String: String]>("cookieStore", default: [:])
 
     #if os(macOS)
     // window management:

--- a/SwiftUI/Model/LibraryOperations.swift
+++ b/SwiftUI/Model/LibraryOperations.swift
@@ -149,7 +149,7 @@ ZIM file cannot be opened: \(zimFile.name, privacy: .public) |\
 
     // MARK: - Deletion
 
-    /// Unlink a zim file from library, delete associated bookmarks, and delete the file.
+    /// Unlink a zim file from library, delete associated bookmarks, cookies and delete the file.
     /// - Parameter zimFile: the zim file to delete
     @ZimActor static func delete(zimFileID: UUID) async {
         guard let url = ZimFileService.shared.getFileURL(zimFileID: zimFileID) else { return }
@@ -157,10 +157,11 @@ ZIM file cannot be opened: \(zimFile.name, privacy: .public) |\
         await LibraryOperations.unlink(zimFileID: zimFileID)
     }
 
-    /// Unlink a zim file from library, delete associated bookmarks, but don't delete the file.
+    /// Unlink a zim file from library, delete associated bookmarks, cookies, but don't delete the file.
     /// - Parameter zimFile: the zim file to unlink
     @ZimActor static func unlink(zimFileID: UUID) async {
         ZimFileService.shared.close(fileID: zimFileID)
+        await MainActor.run { CookieStore.shared.deleteAllFor(zimFileID: zimFileID) }
         await Database.shared.viewContext.perform {
             let request = ZimFile.fetchRequest(fileID: zimFileID)
             request.fetchLimit = 1

--- a/Tests/ZimCookieStoreTest.swift
+++ b/Tests/ZimCookieStoreTest.swift
@@ -1,0 +1,79 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Testing
+@testable import Kiwix
+
+@MainActor
+struct ZimCookieStoreTest {
+
+    struct CookiesT {
+        let value: String
+        let expectedResult: String
+        init(_ value: String, _ expectedResult: String) {
+            self.value = value
+            self.expectedResult = expectedResult
+        }
+    }
+
+    // swiftlint:disable line_length
+    @Test(
+        "Valid JSON input",
+        arguments: [
+            """
+[["theme",{"value":"dark","expiryDate":"2027-08-15T18:18:42.026Z"}],["_pk_id.3.d4b8",{"value":"7b0a9ee549f25c24.0.1.0.0.","expiryDate":"2027-09-12T18:18:38.000Z"}],["_pk_ses.3.d4b8",{"value":"1","expiryDate":"2026-08-15T18:48:38.000Z"}],["width",{"value":"narrow","expiryDate":"2027-08-15T18:18:40.797Z"}]]
+""",
+            """
+[["myKey",{"value":"O'Reilly","expiryDate":"2026-08-17T04:45:16.000Z"}]]
+"""
+        ]
+    )
+    func validInput(json: String) async throws {
+        let mockPersistence = MockPersistence()
+        let storage = ZimCookieStore(persistence: mockPersistence)
+        let fileID = UUID()
+        storage.save(zimFileID: fileID, cookies: json)
+        #expect(storage.getAllFor(zimFileID: fileID) == json)
+        #expect(mockPersistence.load() == [fileID: json])
+    }
+    // swiftlint:enable line_length
+
+    @Test("empty store value deletes the whole store for the given ZIM file", arguments: ["", "[]"])
+    func emptyStoreDeletes(json: String) async throws {
+        let mockPersistance = MockPersistence()
+        let fileID = UUID(uuidString: "C6534BDD-54C0-4A9D-9031-F9222A6520CB")!
+        let otherFileID = UUID(uuidString: "B488A934-7A85-47ED-974F-3AEC752E53BC")!
+        let mockJsonValue = "[other mock json value]"
+
+        mockPersistance.save([otherFileID: mockJsonValue,
+                                   fileID: "[the current file json value]"])
+
+        #expect(!mockPersistance.load().isEmpty)
+        let store = ZimCookieStore(persistence: mockPersistance)
+        store.save(zimFileID: fileID, cookies: json)
+        #expect(mockPersistance.load()[fileID] == nil)
+        #expect(mockPersistance.load()[otherFileID] == mockJsonValue)
+    }
+}
+
+private final class MockPersistence: ZIMCookiePersistence {
+    private var stored: [UUID: String] = [:]
+    func load() -> [UUID: String] {
+        stored
+    }
+    func save(_ values: [UUID: String]) {
+        stored = values
+    }
+}

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -93,6 +93,7 @@ import CoreKiwix
     @MainActor var zimFileId: UUID? { url?.zimFileID }
     @Published var externalURL: URL?
     private var metaData: URLContentMetaData?
+    private let cookieStore = CookieStore.shared
 
 #if os(macOS)
     private var windowURLs: [URL] {
@@ -135,6 +136,8 @@ import CoreKiwix
         webView.configuration.userContentController.add(self, name: "headings")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "geolocation")
         webView.configuration.userContentController.add(self, name: "geolocation")
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "zimCookies")
+        webView.configuration.userContentController.add(self, name: "zimCookies")
         webView.navigationDelegate = self
         webView.uiDelegate = self
 
@@ -175,7 +178,7 @@ import CoreKiwix
                     self?.isLoading = change.newValue
                 }
                 if change.newValue == false {
-                    BrowserTabPreloader.shared.didLoadFirstBrowserTab()                    
+                    BrowserTabPreloader.shared.didLoadFirstBrowserTab()
                 }
             }
         }
@@ -196,6 +199,7 @@ import CoreKiwix
         let contentController = webView.configuration.userContentController
         contentController.removeScriptMessageHandler(forName: "headings")
         contentController.removeScriptMessageHandler(forName: "geolocation")
+        contentController.removeScriptMessageHandler(forName: "zimCookies")
         contentController.removeAllUserScripts()
         webView.navigationDelegate = nil
         webView.uiDelegate = nil
@@ -330,6 +334,18 @@ import CoreKiwix
         }
         webView.load(URLRequest(url: url))
         self.url = url
+    }
+    
+    @MainActor
+    func injectCookies() {
+        guard let zimFileID = webView.url?.zimFileID else { return }
+        guard let jsonValues: String = cookieStore.getAllFor(zimFileID: zimFileID) else {
+            Log.Cookies.debug("no ZIM Cookies for: \(zimFileID.uuidString)")
+            return
+        }
+        Log.Cookies.debug("setting ZIM Cookies: \(jsonValues)")
+        let jsCmd = "setZIMCookies('\(jsonValues)');"
+        webView.evaluateJavaScript(jsCmd)
     }
 
     @MainActor
@@ -524,6 +540,9 @@ import CoreKiwix
     }
 
     func webView(_ webView: WKWebView, didCommit _: WKNavigation!) {
+        // this is the earliest point in time we can inject the stored cookies
+        // webView(:didFinish:) is too late for it
+        injectCookies()
         // The previous document's geolocation callbacks are gone
         geolocationService?.stopAll()
     }
@@ -578,6 +597,10 @@ import CoreKiwix
         } else if message.name == "geolocation", let body = message.body as? [String: Any] {
             guard let request = GeolocationRequest(jsRequest: body) else { return }
             ensureGeolocationService().handle(request: request)
+        } else if message.name == "zimCookies", let body = message.body as? String {
+            if let zimFileId {
+                cookieStore.save(zimFileID: zimFileId, cookies: body)
+            }
         }
     }
     

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -344,8 +344,12 @@ import CoreKiwix
             return
         }
         Log.Cookies.debug("setting ZIM Cookies: \(jsonValues)")
-        let jsCmd = "setZIMCookies('\(jsonValues)');"
-        webView.evaluateJavaScript(jsCmd)
+        let jsCmd = "setZIMCookies(\(String(reflecting: jsonValues)));"
+        webView.evaluateJavaScript(jsCmd) { _, error in
+            if let error {
+                Log.Cookies.error("injectCookies: \(jsCmd)\nfailed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
     }
 
     @MainActor

--- a/project.yml
+++ b/project.yml
@@ -124,6 +124,7 @@ targets:
           - "**/qqq.lproj"
           - "**/igl.lproj"
           - "**/dag.lproj"
+          - "zimCookieTests/**"
       - path: Kiwix/SplashScreenKiwix.storyboard
         destinationFilters:
           - iOS


### PR DESCRIPTION
#### Fixes: #1657 

## Impact for end user
Now we are able to store on the App side the document.cookie values, and update them accordingly. This means that the websites within the ZIMs will remember those user settings.

## Added:
Javascript shim to capture the document.cookie setter as it happens before it hits the html cookie store, which is not working in our case (we are not on a http scheme).
This value gets parsed on the JS side and stored. On each change it will be also sent down the wire to the application, which stores it per ZIM file id, in a JSON serialized format.

The same values stored are then injected back into JS right before the page loads, and can be read the same way as it would come from the browser's original document.cookie getter.

The entries in the cookie store associated with the ZIM file are removed once we "unlink" it from the application (unlink / delete it within the app).

## Compared to: https://github.com/kiwix/kiwix-apple/pull/1666
See comment: https://github.com/kiwix/kiwix-apple/pull/1666#discussion_r3778707124
We keep the state and the parsing of the cookies on the JS side. This has the following **benefits**:
- the code can be more easily ported to other platforms
- we can (and do) test the behavior of the parsing and compare it directly with the browser's `document.cookie` API
- less code, especially less mixed code. The native side doesn't do anything complex that is JS related

**Downsides**:
- we push the whole cookie store per ZIM file on each cookie change rather than individual values, as the source of truth about the state is on the JS side. As the amount of data is still small, I think it is acceptable.

## Testing: 
The ``Support/zimCookiesTests`` folder has been added (this is excluded from the Bundle of the application), which can be opened in a browser and that can validate the JS parsing in a simple way, just by opening the ``index.html`` in a browser:

<img width="488" height="224" alt="Screenshot 2026-08-15 at 14 40 52" src="https://github.com/user-attachments/assets/e694f6fc-e274-4d6e-8b97-b6cdff77977b" />


## Additional findings:
The wombat.js (web archiver), overrides the javascript ``new Date()`` function, and that returns unix timestamp zero (1970). It came as a surprise, as it was hard to figure out what is going on. Anyway, I have found a way around that as well.


### Tested on
- [ ] **iPhone**
- [x] **mac**
- [x] **iPad**

https://github.com/user-attachments/assets/fff13b8c-c46d-4250-868d-0d48f0f7850a


