### PR TITLE
Persist cookies in file, that is synced to iCloud

### DIFF
--- a/Model/Utilities/Debouncer.swift
+++ b/Model/Utilities/Debouncer.swift
@@ -15,7 +15,18 @@
 
 import Foundation
 
-enum CookieStore {
-    @MainActor
-    static let shared = ZimCookieStore(persistence: CookiePersistenceInFiles())
+@MainActor
+final class Debouncer {
+    private var task: Task<Void, Never>?
+    
+    func debounce(milliseconds: UInt64, action: @escaping @Sendable () async -> Void) {
+        task?.cancel()
+        let nanoseconds = milliseconds * 1_000_000
+        task = Task(priority: .utility, operation: {
+            try? await Task.sleep(nanoseconds: nanoseconds)
+            if !Task.isCancelled {
+                await action()
+            }
+        })
+    }
 }

--- a/Model/WebViewConfig/Cookies/ZimCookiePersistence.swift
+++ b/Model/WebViewConfig/Cookies/ZimCookiePersistence.swift
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
-import Defaults
 import Foundation
+import OSLog
 
 @MainActor protocol ZIMCookiePersistence {
     func load() -> [UUID: String]
@@ -22,19 +22,59 @@ import Foundation
 }
 
 @MainActor
-final class CookiePersistenceInDefaults: ZIMCookiePersistence {
-    func load() -> [UUID: String] {
-        let storedValues: [String: String] = Defaults[.cookieStore]
-        return storedValues.reduce(into: .init(), { partialResult, zimFileIdCookies in
-            if let zimFileId = UUID(uuidString: zimFileIdCookies.key) {
-                partialResult.updateValue(zimFileIdCookies.value, forKey: zimFileId)
-            }
-        })
+final class CookiePersistenceInFiles: ZIMCookiePersistence {
+    private let fileURL: URL
+    private let debouncer: Debouncer
+    init() {
+        fileURL = URL.documentsDirectory.appending(component: "zimCookies.json", directoryHint: .notDirectory)
+        debouncer = Debouncer()
     }
-    func save(_ values: [UUID: String]) {
-        let storedValues: [String: String] = values.reduce(into: [:]) { nextPartialResult, zimFileIDValue in
-            nextPartialResult.updateValue(zimFileIDValue.value, forKey: zimFileIDValue.key.uuidString)
+    func load() -> [UUID: String] {
+        let path = fileURL.path()
+        guard FileManager.default.fileExists(atPath: path) else {
+            return [:]
         }
-        Defaults[.cookieStore] = storedValues
+        guard let data = FileManager.default.contents(atPath: path) else {
+            Log.Cookies.error("unable to read data from file \(path)")
+            return [:]
+        }
+        guard let values: [UUID: String] = try? JSONDecoder().decode([UUID: String].self, from: data) else {
+            Log.Cookies.error("unable to decode data from: \(path)")
+            return [:]
+        }
+        return values
+    }
+
+    func save(_ values: [UUID: String]) {
+        let fileURL = self.fileURL
+        debouncer.debounce(milliseconds: 1500) {
+            await Self.saveToFile(values, fileURL: fileURL)
+        }
+    }
+    
+    nonisolated private static func saveToFile(_ values: [UUID: String], fileURL: URL) async {
+        guard let data = try? JSONEncoder().encode(values) else {
+#if DEBUG
+            Log.Cookies.error("cannot encode data: \(values)")
+#else
+            Log.Cookies.error("cannot encode data: \(values.count)")
+#endif
+            return
+        }
+        let path = fileURL.path()
+        do {
+            if !FileManager.default.fileExists(atPath: path) {
+                if FileManager.default.createFile(atPath: path, contents: data) {
+                    Log.Cookies.info("created and saved data to: \(path)")
+                } else {
+                    Log.Cookies.error("couldn't create and write data to: \(path)")
+                }
+            } else {
+                try data.write(to: fileURL, options: [.atomic])
+                Log.Cookies.info("saved data to: \(path)")
+            }
+        } catch {
+            Log.Cookies.error("unable to write data to: \(path)")
+        }
     }
 }

--- a/SwiftUI/Model/DefaultKeys.swift
+++ b/SwiftUI/Model/DefaultKeys.swift
@@ -55,8 +55,6 @@ extension Defaults.Keys {
     static let selectedHotspotIds = Key<Set<UUID>>("slectedHotspotIds", default: Set<UUID>())
     static let openZIMsShowBy = Key<ZIMsShowBy>("openZIMsShowBy", default: ZIMsShowBy.all)
     static let opneZIMsSorting = Key<ZIMsSortBy>("openZIMsSortBy", default: ZIMsSortBy.size(.forward))
-    
-    static let cookieStore = Key<[String: String]>("cookieStore", default: [:])
 
     #if os(macOS)
     // window management:


### PR DESCRIPTION
#### Fixes: #1675 

## Impact for end user
Cookies are saved in a local file, that iCloud will sync.

## Note: this is stacked on top of the PR: https://github.com/kiwix/kiwix-apple/pull/1679

### Tested on
- [x] **iPhone**
- [x] **iPad**
- [x] **mac**