### PR TITLE
Support javascript CookieStore API

### DIFF
--- a/Support/zimCookieTests/README.md
+++ b/Support/zimCookieTests/README.md
@@ -1,0 +1,19 @@
+To run these javascript unit tests, you need to run symlink 2 files via CLI (from this test folder):
+```
+ln -s ../icon.png icon.png
+ln -s ../zimCookies.js zimCookies.js
+```
+
+To have a true comparison between the ZimCookieStore implemenation and the browser supported API, the SHIMs should be commented out in the zimCookies.js file, starting here:
+```
+(function () {
+    // document.cookie SHIM
+```
+
+With that ready you can run it by using a local server:
+```
+python3 -m http.server
+```
+
+Note: the Cookie Store API is not working in Safari browser over pure http, it requires https.
+Nevertheless the tests can be run fine in Firefox, where everything runs OK.

--- a/Support/zimCookieTests/cookie_store_api_tests.js
+++ b/Support/zimCookieTests/cookie_store_api_tests.js
@@ -1,0 +1,123 @@
+(async () => {
+    divider("Cookie Store API tests");
+
+    await asyncIt("set one and getAll cookies", async () => {
+        const store = new ZimCookieStore();
+        await store.set("testKey", "some value");
+        await cookieStore.set("testKey", "some value");
+
+        const zimCookies = await store.getAll();
+        const realCookies = await cookieStore.getAll();
+        // clean up:
+        return assertEqualCookies(zimCookies, realCookies);
+    });
+    // clean up
+    await cookieStore.delete("testKey");
+
+    const kv1 = { key: "key1", value: "one value is 1" };
+    const kv2 = { key: "key2", value: "two value is 2" };
+    await asyncIt("set two cookies and get them back one by one", async () => {
+        const store = new ZimCookieStore();
+        await store.set(kv1.key, kv1.value);
+        await store.set(kv2.key, kv2.value);
+        await cookieStore.set(kv1.key, kv1.value);
+        await cookieStore.set(kv2.key, kv2.value);
+        const storeResults = [await store.get(kv1.key), await store.get(kv2.key)];
+        const cookieResults = [await cookieStore.get(kv1.key), await cookieStore.get(kv2.key)];
+        return assertEqualCookies(storeResults, cookieResults);
+    });
+    // clean up
+    await cookieStore.delete(kv1.key);
+    await cookieStore.delete(kv2.key);
+
+    const key = "random";
+    await asyncIt("overwrite a value", async () => {
+        const store = new ZimCookieStore();
+        await store.set(key, "first value");
+        await cookieStore.set(key, "first value");
+        const finalValue = "other value";
+        await store.set(key, finalValue);
+        await cookieStore.set(key, finalValue);
+        return assertEqualCookies(await store.getAll(), await cookieStore.getAll());
+    });
+    // clean up
+    cookieStore.delete(key);
+
+    await asyncIt("setting an expiry date", async () => {
+        const store = new ZimCookieStore();
+        await store.set({ name: key, value: "obj value", maxAge: 20 });
+        await cookieStore.set({ name: key, value: "obj value", maxAge: 20 });
+        const zimCookies = await store.getAll();
+        const realCookies = await cookieStore.getAll();
+        return assertEqualCookies(zimCookies, realCookies);
+    });
+
+    await asyncIt("delete a value", async () => {
+        const store = new ZimCookieStore();
+        await store.set(key, "some value");
+        await cookieStore.set(key, "some value");
+        await store.delete(key);
+        await cookieStore.delete(key);
+        return assertEqualCookies(await store.getAll(), await cookieStore.getAll());
+    });
+
+    await asyncIt("delete by object key", async () => {
+        const store = new ZimCookieStore();
+        await store.set(key, "some value");
+        await cookieStore.set(key, "some value");
+        await store.delete({ name: key });
+        await cookieStore.delete({ name: key });
+        return assertEqualCookies(await store.getAll(), await cookieStore.getAll());
+    });
+
+    await asyncIt("getAll by key", async () => {
+        const store = new ZimCookieStore();
+        await store.set(kv1.key, kv1.value);
+        await store.set(kv2.key, kv2.value);
+        await cookieStore.set(kv1.key, kv1.value);
+        await cookieStore.set(kv2.key, kv2.value);
+
+        const storeResult = await store.getAll(kv1.key);
+        const cookieResult = await cookieStore.getAll(kv1.key);
+        return assertEqualCookies(storeResult, cookieResult);
+    });
+    await cookieStore.delete(kv1.key); // clean up
+    await cookieStore.delete(kv2.key); // clean up
+
+    await asyncIt("get by object key", async () => {
+        const store = new ZimCookieStore();
+        await store.set(key, "extra");
+        await cookieStore.set(key, "extra");
+
+        const storeResult = await store.get({ name: key });
+        const cookieResult = await cookieStore.get({ name: key });
+        return assertEqualCookie(storeResult, cookieResult);
+    });
+    await cookieStore.delete(key); // clean up
+
+    await asyncIt("try to get an expired cookie", async () => {
+        const store = new ZimCookieStore();
+        const inThePast = new Date(Date.now() - 9999999);
+        const now = new Date();
+        const futureDate = new Date(Date.now() + 9999999);
+        await store.set(
+            { name: key, value: "expired in distant past", expires: now.getTime() },
+            undefined,
+            undefined,
+            inThePast,
+        );
+        const storeResult = await store.get(key, futureDate);
+        return assertEqual(storeResult === null, true);
+    });
+
+    await asyncIt("try to get value by non existing key", async () => {
+        const store = new ZimCookieStore();
+        const cookieResult = await cookieStore.get("non-existing");
+        const storeResult = await store.get("non-existing");
+        return assertEqual(storeResult, cookieResult);
+    });
+
+    await asyncIt("check clean ups", async () => {
+        return assertEqualCookies(await cookieStore.getAll(), []);
+    });
+})();

--- a/Support/zimCookieTests/cookie_tests.js
+++ b/Support/zimCookieTests/cookie_tests.js
@@ -1,119 +1,127 @@
+divider("document.cookie tests");
+
 it("sets up the cookie store with empty value", () => {
-  const store = new ZimCookieStore();
-  store.load("[]");
-  return assertEqual(store.cookies(), "");
+    const store = new ZimCookieStore();
+    store.load("[]");
+    return assertEqual(store.cookies(), "");
 });
 
 it("sets up the cookie store with json values", () => {
-  const store = new ZimCookieStore();
-  store.load(
-    '[["name",{"value":"Kiwix Tester","expiryDate":null}],["_pk_id",{"value":"b40=a8","expiryDate":"2027-09-05T19:14:17.000Z"}],["theme",{"value":"dark","expiryDate":"2027-08-14T09:00:00.000Z"}]]',
-  );
-  return assertEqual(
-    store.cookies(),
-    "name=Kiwix Tester; _pk_id=b40=a8; theme=dark",
-  );
+    const store = new ZimCookieStore();
+    store.load(
+        '[["name",{"value":"Kiwix Tester","expiryDate":null}],["_pk_id",{"value":"b40=a8","expiryDate":"2027-09-05T19:14:17.000Z"}],["theme",{"value":"dark","expiryDate":"2027-08-14T09:00:00.000Z"}]]',
+    );
+    return assertEqual(store.cookies(), "name=Kiwix Tester; _pk_id=b40=a8; theme=dark");
 });
 
 it("handles invalid load data gracefully", () => {
-  const store = new ZimCookieStore();
-  store.load('invalid_data');
-  return assertEqual(store.cookies(), "");
+    const store = new ZimCookieStore();
+    store.load("invalid_data");
+    return assertEqual(store.cookies(), "");
+});
+
+it("handles single quoted data", () => {
+    const store = new ZimCookieStore();
+    store.save("myKey=O'Reilly; max-age=123456", new Date(1786818460000));
+    return assertEqual(
+        store.valueToPersist(),
+        '[["myKey",{"value":"O\'Reilly","expiryDate":"2026-08-17T04:45:16.000Z"}]]',
+    );
 });
 
 it("stores a cookie with a value", () => {
-  const store = new ZimCookieStore();
-  const testCookie = "myKey=value;";
-  store.save(testCookie);
-  document.cookie = testCookie;
-  return assertEqual(store.cookies(), document.cookie);
+    const store = new ZimCookieStore();
+    const testCookie = "myKey=value;";
+    store.save(testCookie);
+    document.cookie = testCookie;
+    return assertEqual(store.cookies(), document.cookie);
 });
 
 it("stores an empty value cookie", () => {
-  const store = new ZimCookieStore();
-  const testCookie = "myKey=;";
-  store.save(testCookie);
-  document.cookie = testCookie;
-  return assertEqual(store.cookies(), document.cookie);
+    const store = new ZimCookieStore();
+    const testCookie = "myKey=;";
+    store.save(testCookie);
+    document.cookie = testCookie;
+    return assertEqual(store.cookies(), document.cookie);
 });
 
 it("removes a cookie, using max-age = 0", () => {
-  const store = new ZimCookieStore();
-  const testCookie1 = "myKey=oldValue;";
-  const testCookie2 = "myKey=oldValue; max-age=0;";
-  store.save(testCookie1);
-  store.save(testCookie2);
-  document.cookie = testCookie1;
-  document.cookie = testCookie2;
-  return assertEqual(store.cookies(), document.cookie);
+    const store = new ZimCookieStore();
+    const testCookie1 = "myKey=oldValue;";
+    const testCookie2 = "myKey=oldValue; max-age=0;";
+    store.save(testCookie1);
+    store.save(testCookie2);
+    document.cookie = testCookie1;
+    document.cookie = testCookie2;
+    return assertEqual(store.cookies(), document.cookie);
 });
 
 it("won't store expired values", () => {
-  const store = new ZimCookieStore();
-  store.save(
-    "my_key=some_value; Expires=Sun, 05 Sep 2027 19:14:00 GMT;",
-    new Date("Sun, 05 Sep 2027 19:14:01 GMT"), // we are a second later already
-  );
-  return assertEqual(store.cookies(), "");
+    const store = new ZimCookieStore();
+    store.save(
+        "my_key=some_value; Expires=Sun, 05 Sep 2027 19:14:00 GMT;",
+        new Date("Sun, 05 Sep 2027 19:14:01 GMT"), // we are a second later already
+    );
+    return assertEqual(store.cookies(), "");
 });
 
 it("will return the same as document.cookie for multiple values", () => {
-  const store = new ZimCookieStore();
-  const cookiesToSet = [
-    "name=Kiwix Tester;max-age=300",
-    "_pk_id=b40=a; Expires=Sun, 05 Sep 2157 19:14:17 GMT;SameSite=Lax",
-    "theme=dark;;max-age=31536000",
-  ];
-  cookiesToSet.forEach((cookie) => {
-    store.save(cookie);
-    document.cookie = cookie;
-  });
-  const valueToPersist = store.valueToPersist();
-  const newStore = new ZimCookieStore();
-  newStore.load(valueToPersist);
+    const store = new ZimCookieStore();
+    const cookiesToSet = [
+        "name=Kiwix Tester;max-age=300",
+        "_pk_id=b40=a; Expires=Sun, 05 Sep 2157 19:14:17 GMT;SameSite=Lax",
+        "theme=dark;;max-age=31536000",
+    ];
+    cookiesToSet.forEach((cookie) => {
+        store.save(cookie);
+        document.cookie = cookie;
+    });
+    const valueToPersist = store.valueToPersist();
+    const newStore = new ZimCookieStore();
+    newStore.load(valueToPersist);
 
-  const stored = newStore
-    .cookies()
-    .split(";")
-    .map((x) => {
-      return x.trim();
-    })
-    .sort();
-  const documented = document.cookie
-    .split(";")
-    .map((x) => {
-      return x.trim();
-    })
-    .sort();
+    const stored = newStore
+        .cookies()
+        .split(";")
+        .map((x) => {
+            return x.trim();
+        })
+        .sort();
+    const documented = document.cookie
+        .split(";")
+        .map((x) => {
+            return x.trim();
+        })
+        .sort();
 
-  return assertEqual(stored, documented);
+    return assertEqual(stored, documented);
 });
 
 it("will set the expiry date correctly", () => {
-  cleanUp();
+    cleanUp();
 
-  const store = new ZimCookieStore();
-  const now = new Date();
-  const cookie = "name=Joe Tester; max-age=31536000";
-  store.save(cookie);
-  document.cookie = cookie;
-  return assertEqual(store.cookies(now), document.cookie);
+    const store = new ZimCookieStore();
+    const now = new Date();
+    const cookie = "name=Joe Tester; max-age=31536000";
+    store.save(cookie);
+    document.cookie = cookie;
+    return assertEqual(store.cookies(now), document.cookie);
 });
 
 it("won't persist session only items (entries with a null expiry date)", () => {
-  const store = new ZimCookieStore();
-  store.save("the_key=is session only;");
-  return assertEqual(store.valueToPersist(), "[]");
+    const store = new ZimCookieStore();
+    store.save("the_key=is session only;");
+    return assertEqual(store.valueToPersist(), "[]");
 });
 
 function cleanUp() {
-  document.cookie.split(";").forEach((cookie) => {
-    const cookieName = cookie.split("=")[0].trim();
-    // Set cookie max-age to 0 date delete it
-    document.cookie = `${cookieName}=; max-age=0;`;
-  });
+    document.cookie.split(";").forEach((cookie) => {
+        const cookieName = cookie.split("=")[0].trim();
+        // Set cookie max-age to 0 date delete it
+        document.cookie = `${cookieName}=; max-age=0;`;
+    });
 }
 it("clean up", () => {
-  cleanUp();
-  return assertEqual(document.cookie, "");
+    cleanUp();
+    return assertEqual(document.cookie, "");
 });

--- a/Support/zimCookieTests/index.html
+++ b/Support/zimCookieTests/index.html
@@ -5,8 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Unit testing</title>
   <script src="test_framework.js"></script>
-  <script src="../zimCookies.js"></script>
+  <script src="zimCookies.js"></script>
   <script defer src="cookie_tests.js"></script>
+  <script defer src="cookie_store_api_tests.js"></script>
+  <link rel="icon" type="image/x-icon" href="icon.png">
   <style>
     .test_result { margin: 0; }
     .success { color: green; }

--- a/Support/zimCookieTests/test_framework.js
+++ b/Support/zimCookieTests/test_framework.js
@@ -3,29 +3,67 @@
  * CC by 4.0 https://creativecommons.org/licenses/by/4.0/
  */
 function it(description, body_of_test) {
-  const result = document.createElement("p");
-  result.classList.add("test_result");
-  let testResult = body_of_test();
-  if (testResult === true) {
-    result.classList.add("success");
-    result.innerHTML = description;
-  } else {
-    result.classList.add("failure");
-    result.innerHTML = `${description}<br/><pre>${testResult}</pre>`;
-  }
-  document.body.appendChild(result);
+    handleResult(description, body_of_test());
+}
+
+function handleResult(description, testResult) {
+    const result = document.createElement("p");
+    result.classList.add("test_result");
+    if (testResult === true) {
+        result.classList.add("success");
+        result.innerHTML = description;
+    } else {
+        result.classList.add("failure");
+        result.innerHTML = `${description}<br/><pre>${testResult}</pre>`;
+    }
+    document.body.appendChild(result);
+}
+
+function divider(text) {
+    const result = document.createElement("p");
+    const mark = "-";
+    result.innerHTML = `${mark.repeat(20)} ${text} ${mark.repeat(20)}`;
+    document.body.appendChild(result);
+}
+
+async function asyncIt(description, body_of_test) {
+    handleResult(description, await body_of_test());
 }
 
 function assertEqual(x, y) {
-  if (
-    x === y ||
-    (typeof x === "object" &&
-      typeof y === "object" &&
-      x.length === y.length &&
-      x.every((element, index) => element === y[index]))
-  ) {
-    return true;
-  } else {
+    if (x === y) {
+        return true;
+    }
+    if (areObjects(x, y) && equalObjects(x, y)) {
+        return true;
+    }
     return `${x} != ${y}`;
-  }
+}
+
+function assertEqualCookies(x, y) {
+    if (areObjects(x, y) && x.length === y.length && x.every((element, index) => equalCookies(element, y[index]))) {
+        return true;
+    }
+    console.log({ x }, { y });
+    return `${x} != ${y}`;
+}
+
+function assertEqualCookie(x, y) {
+    if (areObjects(x, y) && equalCookies(x, y)) {
+        return true;
+    }
+    console.log({ x }, { y });
+    return `${x} != ${y}`;
+}
+
+function areObjects(x, y) {
+    return typeof x === "object" && typeof y === "object";
+}
+
+function equalObjects(x, y) {
+    return x.length === y.length && x.every((element, index) => element === y[index]);
+}
+
+function equalCookies(x, y) {
+    return x.name === y.name && x.value === y.value;
 }

--- a/Support/zimCookies.js
+++ b/Support/zimCookies.js
@@ -1,144 +1,283 @@
 // go around Wombat.js overriding Date.now()
 function currentDate() {
-  if(typeof(__wb_Date_now) == "function") {
-    return new Date(__wb_Date_now());
-  }
-  return new Date();
+    if (typeof __wb_Date_now == "function") {
+        return new Date(__wb_Date_now());
+    }
+    return new Date();
 }
+
+const construct = (type, values) => ({
+    case: (cases) => cases[type].apply(null, values),
+});
+
+// possible outcomes of maxDate | expiryDate values
+const ExpiryCheck = {
+    Date: (dateValue) => construct("Date", [dateValue]),
+    NoDate: construct("NoDate", []),
+    Expired: construct("Expired", []),
+};
 
 class ZimCookieStore {
-  constructor() {
-    this.store = new Map();
-  }
-
-  cookies(now = currentDate()) {
-    var parts = new Array();
-    for (const [key, valueAndDate] of this.store.entries()) {
-      const { expiryDate: expDate } = valueAndDate;
-      if (expDate != null && expDate <= now) {
-        continue;
-      } else {
-        const { value: cookieValue } = valueAndDate;
-        parts.push([key, cookieValue].join("="));
-      }
-    }
-    return parts.join("; ");
-  }
-
-  save(cookie, now = currentDate()) {
-    const [keyValue, ...attributes] = String(cookie).split(";");
-    const [rawKey, ...rawVal] = String(keyValue ?? "").split("=");
-    const key = (rawKey ?? "").trim();
-    const value = rawVal.join("=").trim();
-    if (!key) {
-      console.warn("invalid cookie key:", key);
-      return;
+    constructor() {
+        this.store = new Map();
     }
 
-    const attrMap = new Map(
-      attributes
-        .map((s) => String(s).trim())
-        .filter(Boolean)
-        .map((s) => {
-          const [k, ...v] = s.split("=");
-          return [String(k).trim().toLowerCase(), v.join("=").trim()];
-        }),
-    );
-    const maxAge = attrMap.get("max-age");
-    const expires = attrMap.get("expires");
-    if (maxAge !== undefined) {
-      const maxAgeNumber = Number(maxAge);
-      if (Number.isFinite(maxAgeNumber)) {
-        if (maxAgeNumber <= 0) {
-          this.store.delete(key);
-          return;
-        } else {
-          const expiry = new Date(now.getTime() + maxAgeNumber * 1000);
-          this.store.set(key, {
-            value: value,
-            expiryDate: expiry,
-          });
-          return;
+    // document.cookie API
+    cookies(now = currentDate()) {
+        var parts = new Array();
+        var expiredKeys = new Array();
+        for (const [key, valueAndDate] of this.store.entries()) {
+            if (this.isExpired(valueAndDate, now)) {
+                expiredKeys.push(key);
+            } else {
+                const { value: cookieValue } = valueAndDate;
+                parts.push([key, cookieValue].join("="));
+            }
         }
-      }
-    } else if (expires !== undefined) {
-      const expiryDate = new Date(expires);
-      if (!isNaN(expiryDate)) {
-        if (now < expiryDate) {
-          this.store.set(key, {
-            value: value,
-            expiryDate: expiryDate,
-          });
-          return;
-        } else {
-          this.store.delete(key);
-          return;
+        expiredKeys.forEach((key) => this.store.delete(key));
+        return parts.join("; ");
+    }
+
+    save(cookie, now = currentDate()) {
+        const [keyValue, ...attributes] = String(cookie).split(";");
+        const [rawKey, ...rawVal] = String(keyValue ?? "").split("=");
+        const key = (rawKey ?? "").trim();
+        const value = rawVal.join("=").trim();
+        if (!key) {
+            console.warn("invalid cookie key:", key);
+            return;
         }
-      }
+
+        const attrMap = new Map(
+            attributes
+                .map((s) => String(s).trim())
+                .filter(Boolean)
+                .map((s) => {
+                    const [k, ...v] = s.split("=");
+                    return [String(k).trim().toLowerCase(), v.join("=").trim()];
+                }),
+        );
+        const maxAge = attrMap.get("max-age");
+        const expires = attrMap.get("expires");
+
+        this.mapToExpiry(maxAge, expires, now).case({
+            Date: (expiryDate) => this.store.set(key, { value: value, expiryDate: expiryDate }),
+            NoDate: () => this.store.set(key, { value: value, expiryDate: null }), // session only
+            Expired: () => this.store.delete(key),
+        });
     }
-    // store in session only, without a specific date:
-    this.store.set(key, { value: value, expiryDate: null });
-  }
 
-  valueToPersist() {
-    const entries = Array.from(this.store).filter((entry) => {
-      return entry[1].expiryDate != null;
-    });
-    return JSON.stringify(entries);
-  }
+    // Cookie Store API
+    async set(keyOrOptions, inputValue, inputOptions = {}, now = currentDate()) {
+        let key;
+        let value;
+        let options;
 
-  persist() {
-    const zimCookies = window.webkit?.messageHandlers?.zimCookies;
-    zimCookies?.postMessage(this.valueToPersist());
-  }
+        if (typeof keyOrOptions === "string") {
+            key = keyOrOptions;
+            value = inputValue;
+            options = inputOptions || {};
+        } else {
+            options = keyOrOptions || {};
+            key = options.name;
+            value = options.value;
+        }
 
-  load(values) {
-    try {
-      this.store = new Map(JSON.parse(values));
-    } catch (e) {
-      console.warn('Invalid ZIM cookies payload, resetting store:', e);
-      this.store = new Map();
+        if (!key) {
+            throw new TypeError("Cookie name is required");
+        }
+        if (value === undefined) {
+            throw new TypeError("Cookie value is required");
+        }
+
+        this.mapToExpiry(options.maxAge, options.expires, now).case({
+            Date: (expiryDate) => this.store.set(key, { value: value, expiryDate: expiryDate }),
+            NoDate: () => this.store.set(key, { value: value, expiryDate: null }), // session only
+            Expired: () => this.store.delete(key),
+        });
     }
-  }
+
+    async getAll(keyOrOptions, now = currentDate()) {
+        const key = keyOrOptions === undefined ? undefined : this.getKeyFrom(keyOrOptions);
+        const result = [];
+        for (const [name, valueAndDate] of this.store) {
+            if (this.isExpired(valueAndDate, now)) {
+                this.store.delete(name);
+                continue;
+            }
+            if (key === undefined || name === key) {
+                result.push({
+                    name,
+                    value: valueAndDate.value,
+                });
+            }
+        }
+        return result;
+    }
+
+    async get(keyOrOptions, now = currentDate()) {
+        const key = this.getKeyFrom(keyOrOptions);
+        const valueAndDate = this.store.get(key);
+        if (valueAndDate === undefined) {
+            return null;
+        }
+        if (this.isExpired(valueAndDate, now)) {
+            this.store.delete(key);
+            return null;
+        }
+        return { name: key, value: valueAndDate.value };
+    }
+
+    async delete(keyOrOptions) {
+        const key = this.getKeyFrom(keyOrOptions);
+        this.store.delete(key);
+    }
+
+    // helpers
+    mapToExpiry(maxAge, expires, now) {
+        // for inputs
+        if (maxAge !== undefined) {
+            const maxAgeNumber = Number(maxAge);
+            if (Number.isFinite(maxAgeNumber)) {
+                if (maxAgeNumber <= 0) {
+                    return ExpiryCheck.Expired;
+                } else {
+                    const expiry = new Date(now.getTime() + maxAgeNumber * 1000);
+                    return ExpiryCheck.Date(expiry);
+                }
+            }
+        } else if (expires !== undefined) {
+            const expiryDate = new Date(expires);
+            if (!isNaN(expiryDate)) {
+                if (now < expiryDate) {
+                    return ExpiryCheck.Date(expiryDate);
+                } else {
+                    return ExpiryCheck.Expired;
+                }
+            }
+        }
+        return ExpiryCheck.NoDate;
+    }
+
+    isExpired(valueAndDate, now) {
+        //for outputs
+        return valueAndDate.expiryDate != null && valueAndDate.expiryDate <= now;
+    }
+
+    getKeyFrom(keyOrOptions) {
+        if (typeof keyOrOptions === "string") {
+            return keyOrOptions;
+        }
+        if (keyOrOptions !== null && typeof keyOrOptions === "object") {
+            const key = keyOrOptions.name;
+            if (!key) {
+                throw new TypeError("Cookie name is required");
+            }
+            return key;
+        }
+        throw new TypeError("Cookie name is required");
+    }
+
+    // persistence
+
+    valueToPersist() {
+        const entries = Array.from(this.store).filter((entry) => {
+            return entry[1].expiryDate != null;
+        });
+        return JSON.stringify(entries);
+    }
+
+    persist() {
+        const zimCookies = window.webkit?.messageHandlers?.zimCookies;
+        zimCookies?.postMessage(this.valueToPersist());
+    }
+
+    load(values) {
+        try {
+            this.store = new Map(JSON.parse(values));
+        } catch (e) {
+            console.warn("Invalid ZIM cookies payload, resetting store:", e);
+            this.store = new Map();
+        }
+    }
 }
 
-// SHIM
-var __zimCookieStore = new ZimCookieStore();
+// Cookie Store API Wrapper
+class CookieStoreShim {
+    #store = __zimCookieStore;
+
+    async set(keyOrOptions, inputValue, inputOptions = {}) {
+        await this.#store.set(keyOrOptions, inputValue, inputOptions);
+        this.#store.persist();
+    }
+
+    async get(keyOrOptions) {
+        return this.#store.get(keyOrOptions);
+    }
+
+    async getAll(keyOrOptions) {
+        return this.#store.getAll(keyOrOptions);
+    }
+
+    async delete(keyOrOptions) {
+        await this.#store.delete(keyOrOptions);
+        this.#store.persist();
+    }
+}
+
+// SHIMs
+const __zimCookieStore = new ZimCookieStore();
+const __cookieStoreShim = new CookieStoreShim();
 
 // save the cookies on native side
 function getZIMCookies() {
-  __zimCookieStore.persist();
+    __zimCookieStore.persist();
 }
 
 // injecting cookies from native side here, it should be JSON encoded
 function setZIMCookies(newValue) {
-  __zimCookieStore.load(newValue);
+    __zimCookieStore.load(newValue);
 }
 
 (function () {
-  // 1. Get the original native setter from the Prototype
-  const cookieDescriptor =
-    Object.getOwnPropertyDescriptor(Document.prototype, "cookie") ||
-    Object.getOwnPropertyDescriptor(HTMLDocument.prototype, "cookie");
+    // document.cookie SHIM
 
-  if (!cookieDescriptor) {
-    console.error("Could not find cookie descriptor.");
-    return;
-  }
+    // 1. Get the original native setter from the Prototype
+    const cookieDescriptor =
+        Object.getOwnPropertyDescriptor(Document.prototype, "cookie") ||
+        Object.getOwnPropertyDescriptor(HTMLDocument.prototype, "cookie");
 
-  // 2. Redefine the property with custom hooks
-  Object.defineProperty(Document.prototype, "cookie", {
-    configurable: true,
-    enumerable: true,
+    if (!cookieDescriptor) {
+        console.error("Could not find cookie descriptor.");
+        return;
+    }
 
-    get: function () {
-      return __zimCookieStore.cookies();
-    },
+    // 2. Redefine the property with custom hooks
+    Object.defineProperty(Document.prototype, "cookie", {
+        configurable: true,
+        enumerable: true,
 
-    // Intercept updates
-    set: function (newValue) {
-      __zimCookieStore.save(newValue);
-      __zimCookieStore.persist();
-    },
-  });
+        get: function () {
+            return __zimCookieStore.cookies();
+        },
+
+        // Intercept updates
+        set: function (newValue) {
+            __zimCookieStore.save(newValue);
+            __zimCookieStore.persist();
+        },
+    });
+
+    // Cookie Store API SHIM
+    Object.defineProperty(window, "cookieStore", {
+        configurable: true,
+        enumerable: true,
+
+        get() {
+            return __cookieStoreShim;
+        },
+    });
 })();
+
+// important to let the native side know we are ready for receiving saved cookie values
+window.webkit?.messageHandlers?.zimCookies?.postMessage("zimCookieStoreReady");

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -336,20 +336,24 @@ import CoreKiwix
         self.url = url
     }
     
-    @MainActor
-    func injectCookies() {
-        guard let zimFileID = webView.url?.zimFileID else { return }
-        guard let jsonValues: String = cookieStore.getAllFor(zimFileID: zimFileID) else {
-            Log.Cookies.debug("no ZIM Cookies for: \(zimFileID.uuidString)")
-            return
-        }
-        Log.Cookies.debug("setting ZIM Cookies: \(jsonValues)")
-        let jsCmd = "setZIMCookies(\(String(reflecting: jsonValues)));"
-        webView.evaluateJavaScript(jsCmd) { _, error in
-            if let error {
-                Log.Cookies.error("injectCookies: \(jsCmd)\nfailed: \(error.localizedDescription, privacy: .public)")
+    private func injectCookiesFor(url: URL) {
+        if let zimFileID = url.zimFileID, let jsScript = injectCookieJSScriptFor(zimFileID: zimFileID) {
+            webView.evaluateJavaScript(jsScript) { _, error in
+                if let error {
+                    Log.Cookies.error("unable to inject zimCookies: \(error.localizedDescription, privacy: .public)")
+                } else {
+                    Log.Cookies.debug("injected cookies for: \(zimFileID.uuidString)\n\(jsScript)")
+                }
             }
         }
+    }
+    
+    private func injectCookieJSScriptFor(zimFileID: UUID) -> String? {
+        guard let jsonValues: String = cookieStore.getAllFor(zimFileID: zimFileID) else {
+            Log.Cookies.debug("no ZIM Cookies for: \(zimFileID.uuidString)")
+            return nil
+        }
+        return "setZIMCookies(\(String(reflecting: jsonValues)));"
     }
 
     @MainActor
@@ -543,10 +547,7 @@ import CoreKiwix
         decisionHandler(.allow)
     }
 
-    func webView(_ webView: WKWebView, didCommit _: WKNavigation!) {
-        // this is the earliest point in time we can inject the stored cookies
-        // webView(:didFinish:) is too late for it
-        injectCookies()
+    func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
         // The previous document's geolocation callbacks are gone
         geolocationService?.stopAll()
     }
@@ -602,7 +603,12 @@ import CoreKiwix
             guard let request = GeolocationRequest(jsRequest: body) else { return }
             ensureGeolocationService().handle(request: request)
         } else if message.name == "zimCookies", let body = message.body as? String {
-            if let zimFileId {
+            if body == "zimCookieStoreReady" {
+                Log.Cookies.debug("zimCookieStoreReady")
+                if let url = webView.url {
+                    injectCookiesFor(url: url)
+                }
+            } else if let zimFileId {
                 cookieStore.save(zimFileID: zimFileId, cookies: body)
             }
         }


### PR DESCRIPTION
#### Fixes: #1674 

## Impact for end user
It is now possible to save and load Cookies from ZIM content that is using the newer Cookies Store API.


## Description

- Added: 
JS unit tests covering both document.cookie and CookieStore API
Shim / wrapper for supporting the JS API
Short Readme how to run the JS unit tests locally

## Screenshots

https://github.com/user-attachments/assets/a3bd74aa-016b-4a2b-aa4a-8091d78d27f6

<img width="508" height="566" alt="Screenshot 2026-08-21 at 10 37 01" src="https://github.com/user-attachments/assets/9041e96d-6210-41f2-800d-cf3eaefaabcc" />


## Test ZIM:
[cookiestore_api.zim.zip](https://github.com/user-attachments/files/31296143/cookiestore_api.zim.zip)

### Tested on
- [ ] **iPhone**
- [ ] **iPad**
- [x] **mac**