### PR TITLE
Immerse reading based on webview scroll

### DIFF
--- a/Support/injection.js
+++ b/Support/injection.js
@@ -28,14 +28,23 @@ let observer = new IntersectionObserver(function(entries) {
 	}
 }, { rootMargin: '-50px 0 -35% 0', threshold: 1.0 });
 
-// register scroll view to handle heading on top of the page
+// register scroll view to handle custom show/hide navigation bars
+var lastYOffset = 0;
+var lastDirection = undefined;
 window.onscroll = function() {
-	if (document.documentElement.scrollTop <= 0) {
-		const headingVisible = window.webkit.messageHandlers.headingVisible
-		if(headingVisible !== undefined && headingVisible.postMessage !== undefined) {
-			headingVisible.postMessage({id: headings[0].id})
-		}
-	}
+    const element = document.documentElement;
+    const maxYOffset = element.scrollHeight - element.clientHeight;
+    // trim off the values created by bounce-back animation at the top & bottom of the page
+    // which are over the normal scroll min/max values
+    const yOffset = Math.min(Math.max(element.scrollTop, 0), maxYOffset);
+    if(lastYOffset < yOffset && 50 < yOffset && lastDirection != "down") {
+        lastDirection = "down";
+        window.webkit?.messageHandlers?.scrollHandler?.postMessage("down");
+    } else if(yOffset < lastYOffset && lastDirection != "up") {
+        lastDirection = "up";
+        window.webkit?.messageHandlers?.scrollHandler?.postMessage("up");
+    }
+    lastYOffset = yOffset;
 }
 
 // expand all detail tags

--- a/SwiftUI/Patches.swift
+++ b/SwiftUI/Patches.swift
@@ -78,6 +78,7 @@ extension Notification.Name {
     static let saveContent = Notification.Name("saveContent")
     static let navigateToHotspotSettings = Notification.Name("navigateToHotspotSettings")
     static let toggleSidebar = Notification.Name("toggleSidebar")
+    static let webViewDidScroll = Notification.Name("webViewDidScroll")
     #if os(macOS)
     static let keepOnlyTabs = Notification.Name("keepOnlyTabs")
     static let zimSearch = Notification.Name("zimSearch")

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -108,6 +108,8 @@ import CoreKiwix
     private var canGoForwardObserver: NSKeyValueObservation?
     private var titleURLObserver: AnyCancellable?
     private let bookmarkFetchedResultsController: NSFetchedResultsController<Bookmark>
+    /// Maps to injected javascript: window.webkit?.messageHandlers.*
+    private let jsHandlers = ["headings", "geolocation", "scrollHandler", "zimCookies"]
 
     // MARK: - Lifecycle
 
@@ -132,12 +134,10 @@ import CoreKiwix
         // configure web view
         webView.allowsBackForwardNavigationGestures = true
         webView.configuration.defaultWebpagePreferences.preferredContentMode = .mobile // for font adjustment to work
-        webView.configuration.userContentController.removeScriptMessageHandler(forName: "headings")
-        webView.configuration.userContentController.add(self, name: "headings")
-        webView.configuration.userContentController.removeScriptMessageHandler(forName: "geolocation")
-        webView.configuration.userContentController.add(self, name: "geolocation")
-        webView.configuration.userContentController.removeScriptMessageHandler(forName: "zimCookies")
-        webView.configuration.userContentController.add(self, name: "zimCookies")
+        jsHandlers.forEach { handler in
+            webView.configuration.userContentController.removeScriptMessageHandler(forName: handler)
+            webView.configuration.userContentController.add(self, name: handler)
+        }
         webView.navigationDelegate = self
         webView.uiDelegate = self
 
@@ -197,9 +197,9 @@ import CoreKiwix
         isLoadingObserver?.invalidate()
         geolocationService?.stopAll()
         let contentController = webView.configuration.userContentController
-        contentController.removeScriptMessageHandler(forName: "headings")
-        contentController.removeScriptMessageHandler(forName: "geolocation")
-        contentController.removeScriptMessageHandler(forName: "zimCookies")
+        jsHandlers.forEach { handler in
+            contentController.removeScriptMessageHandler(forName: handler)
+        }
         contentController.removeAllUserScripts()
         webView.navigationDelegate = nil
         webView.uiDelegate = nil
@@ -594,7 +594,7 @@ import CoreKiwix
 
     // MARK: - WKScriptMessageHandler
 
-    @MainActor
+    @MainActor // swiftlint:disable:next cyclomatic_complexity
     func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
         if message.name == "headings", let headings = message.body as? [[String: String]] {
             self.generateOutlineList(headings: headings)
@@ -610,6 +610,14 @@ import CoreKiwix
                 }
             } else if let zimFileId {
                 cookieStore.save(zimFileID: zimFileId, cookies: body)
+            }
+        } else if !Brand.disableImmersiveReading, message.name == "scrollHandler" {
+            switch message.body as? String {
+            case "up": NotificationCenter.default
+                    .post(name: .webViewDidScroll, object: webView, userInfo: ["direction": "up"])
+            case "down": NotificationCenter.default
+                    .post(name: .webViewDidScroll, object: webView, userInfo: ["direction": "down"])
+            default: break
             }
         }
     }

--- a/Views/BuildingBlocks/WebView.swift
+++ b/Views/BuildingBlocks/WebView.swift
@@ -120,6 +120,7 @@ struct WebView: UIViewControllerRepresentable {
 final class WebViewController: UIViewController {
     private let webView: WKWebView
     private let pageZoomObserver: Defaults.Observation
+    private var didScrollTask: Task<Void, Never>?
     
     init(webView: WKWebView) {
         self.webView = webView
@@ -172,8 +173,21 @@ final class WebViewController: UIViewController {
         super.didMove(toParent: parent)
         // navigated to webView
         if !Brand.disableImmersiveReading, let parent {
-            parent.navigationController?.hidesBarsOnSwipe = true
             navController = parent.navigationController
+            didScrollTask = Task { @MainActor in
+                for await notif in NotificationCenter.default
+                    .notifications(named: .webViewDidScroll) where (notif.object as? WKWebView) === webView {
+                    switch notif.userInfo?["direction"] as? String {
+                    case "up":
+                        navController?.setNavigationBarHidden(false, animated: true)
+                        navController?.setToolbarHidden(false, animated: true)
+                    case "down":
+                        navController?.setNavigationBarHidden(true, animated: true)
+                        navController?.setToolbarHidden(true, animated: true)
+                    default: break
+                    }
+                }
+            }
         }
     }
     
@@ -184,6 +198,8 @@ final class WebViewController: UIViewController {
             navController?.isToolbarHidden = false
             navController?.hidesBarsOnSwipe = false
             navController = nil
+            didScrollTask?.cancel()
+            didScrollTask = nil
         }
         super.willMove(toParent: parent)
         


### PR DESCRIPTION
#### Fixes: #1682

## Impact for end user
The navigation bars will be hidden / show in a more appropriate manner.
The user won't be "stuck" on pages without being able to access the navigation icons.

## Description
It turned out that this is a wider issue not specific only to maps, and depends on the content itself. If the scroll is happening on the "top level" everything works OK. However maps and certain wiki home pages do the scrolling not on the top level, but inside a container within the html DOM. This one was not triggering the native scroll events.

## Solution
Instead of relying on the native top level scroll position, we can rely on the html document element, which is more accurate in our cases. For the content where the scroll is happening within these inner containers, like map and wiki home pages we won't be hiding the navigation/tool-bar items.

## BEFORE:

https://github.com/user-attachments/assets/398f0680-4bf6-488f-870f-7585a9093d21
https://github.com/user-attachments/assets/8c6987b3-d1c6-4e20-b0c1-39b7ed83d1b9

## AFTER:
https://github.com/user-attachments/assets/f52a3dd0-21d5-4fe1-972c-a2d225f197bc


### Tested on
- [x] **iPhone**
- [x] **iPad**
- [x] **mac**