### PR TITLE
Accessibility for find in page

### DIFF
--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -53,6 +53,8 @@
 "common.button.share_as_pdf" = "Share as PDF";
 "common.search" = "Search";
 "common.search.inpage" = "Search in page";
+"common.find_next" = "Find next";
+"common.find_previous" = "Find previous";
 "common.search.suggestion" = "Did you mean:";
 
 "common.tab.manager.title" = "Tabs Manager";

--- a/Support/qqq.lproj/Localizable.strings
+++ b/Support/qqq.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "common.button.share_as_pdf" = "Accesibility label for share button. to share the curretly loadded article with an external application in a PDF file format.";
 "common.search" = "The default placeholder text for searchbars, when the search input field is empty";
 "common.search.inpage" = "The default placeholder text for searchbar to find something in the current page, when the search input field is empty";
+"common.find_next" = "The accessibility label for the search in page next result button";
+"common.find_previous" = "The accessibility label for the search in page previous result button";
 "common.search.suggestion" = "Title text for suggestions when the user enters a search term that is misspelled, and we're suggesting alternatives terms to search for.";
 "common.tab.manager.title" = "Accessibility label for button tab bar button that opens an overlay menu.";
 "common.tab.navigation.title" = "On iPad it is a title in the sidemenu grouping tabs related buttons";

--- a/Views/BuildingBlocks/ContentSearchBar.swift
+++ b/Views/BuildingBlocks/ContentSearchBar.swift
@@ -63,6 +63,7 @@ struct ContentSearchBar: View {
             Image(systemName: "text.page.badge.magnifyingglass")
                 .font(.system(size: 18))
         }
+        .accessibilityLabel(LocalString.common_search_inpage)
         .buttonStyle(PlainButtonStyle())
         .padding(24)
     }
@@ -88,6 +89,7 @@ struct ContentSearchBar: View {
     private var searchImage: some View {
         Image(systemName: "magnifyingglass")
             .foregroundColor(.primary)
+            .accessibilityHidden(true)
     }
 
     private var leftButton: some View {
@@ -96,6 +98,7 @@ struct ContentSearchBar: View {
         } label: {
             Image(systemName: "arrowshape.left").foregroundColor(.primary)
         }
+        .accessibilityLabel(LocalString.common_find_previous)
         .keyboardShortcut("g", modifiers: EventModifiers(arrayLiteral: .command, .shift))
     }
 
@@ -105,6 +108,7 @@ struct ContentSearchBar: View {
         } label: {
             Image(systemName: "arrowshape.right").foregroundColor(.primary)
         }
+        .accessibilityLabel(LocalString.common_find_next)
         .keyboardShortcut("g")
     }
 


### PR DESCRIPTION
#### Fixes: #1686 

## Impact for end user
On macOS the search in page functionality is now using appropriate accessibility labels.

## Added accessibility labels for:
- the find in page button (closed panel state)
- find previous button (left arrow)
- find next button (right arrow)

## Removed accessibility:
- from the magnifying glass image icon that is not doing anything for the user (opened panel state)

### Tested
- [x] **mac** with Accessibility Inspector 