### PR TITLE
Add accessibility label to table of contents button

### DIFF
--- a/Views/Buttons/OutlineButton.swift
+++ b/Views/Buttons/OutlineButton.swift
@@ -42,6 +42,7 @@ struct OutlineButton: View {
         } label: {
             Label(LocalString.outline_button_outline_title, systemImage: "list.bullet")
         }
+        .accessibilityLabel(LocalString.outline_button_outline_title)
         .disabled(items.isEmpty)
         .help(LocalString.outline_button_outline_help)
         #elseif os(iOS)


### PR DESCRIPTION
#### Fixes: #1684 

## Impact for end user
The accessibility announcement will be correct for the outline (table of contents) button.

## After
<img width="970" height="213" alt="Screenshot 2026-08-23 at 14 51 53 2" src="https://github.com/user-attachments/assets/575967ed-c456-424f-8338-a34f08759405" />


### Tested on
- [ ] **iPhone**
- [ ] **iPad**
- [x] **mac**