### PR TITLE
Add accessibility for ZimFile cells

### DIFF
--- a/Views/BuildingBlocks/ZimFileCell.swift
+++ b/Views/BuildingBlocks/ZimFileCell.swift
@@ -104,6 +104,10 @@ struct ZimFileCell: View {
         .clipShape(CellBackground.clipShapeRectangle)
         .modifier(LoadingOverlay(isLoading: isLoading))
         .onHover { self.isHovering = $0 }
+        .accessibilityAddTraits(isSelected ? .isSelected : .isButton)
+        .accessibilityElement()
+        .accessibilityLabel(Self.cellAccessibilityLabel(for: zimFile))
+        .accessibilityAddTraits(.isButton)
     }
 
     @MainActor
@@ -123,6 +127,17 @@ struct ZimFileCell: View {
 
     enum Prominent {
         case name, size
+    }
+    
+    static func cellAccessibilityLabel(for zimFile: ZimFile) -> String {
+        [zimFile.name,
+         ZimFileCell.sizeFormatter.string(fromByteCount: zimFile.size),
+         Flavor(rawValue: zimFile.flavor)?.description,
+         "\(zimFile.articleCount.formatted(.number.notation(.compactName).locale(.current)))" + " "
+                                        + LocalString.zim_file_cell_article_count_suffix,
+         ZimFileCell.dateFormatter.string(from: zimFile.created),
+         zimFile.isMissing ? LocalString.zim_file_missing_indicator_help : nil
+        ].compactMap { $0 }.joined(separator: ", ")
     }
 }
 

--- a/Views/BuildingBlocks/ZimFileRow.swift
+++ b/Views/BuildingBlocks/ZimFileRow.swift
@@ -29,7 +29,9 @@ struct ZimFileRow: View {
                 category: Category(rawValue: zimFile.category) ?? .other,
                 imageData: zimFile.faviconData,
                 imageURL: zimFile.faviconURL
-            ).frame(height: 26)
+            )
+            .frame(height: 26)
+            .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 2) {
                 Text(zimFile.name).lineLimit(1)
                 Text([
@@ -44,6 +46,9 @@ struct ZimFileRow: View {
             Spacer()
             if zimFile.isMissing { ZimFileMissingIndicator() }
         }
+        .accessibilityElement()
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(ZimFileCell.cellAccessibilityLabel(for: zimFile))
     }
 }
 


### PR DESCRIPTION
#### Fixes: #1683 

## Impact for end user
Ability to use Voice-Over on ZIM file cells listed under categories.

## Grid

<img width="943" height="898" alt="category_grid" src="https://github.com/user-attachments/assets/5d85b44b-6399-4773-b522-309fa3745200" />

## List
<img width="844" height="848" alt="category_list" src="https://github.com/user-attachments/assets/b72f03f0-b89b-4ca4-9002-b9818d6f9efe" />



### Tested on
- [ ] **iPhone**
- [ ] **iPad**
- [x] **mac** - with Accessibility Inspector