### PR TITLE
Fix search result navigation on macOS

### DIFF
--- a/App/CompactView_iOS.swift
+++ b/App/CompactView_iOS.swift
@@ -20,7 +20,7 @@ import CoreData
 struct CompactView: View {
     @EnvironmentObject private var navigation: NavigationViewModel
     @Environment(\.dismissSearch) private var dismissSearch
-    @ObservedObject private var searchViewModel = SearchViewModel.shared
+    @StateObject var searchViewModel = SearchViewModel()
     private let openURL = NotificationCenter.default.publisher(for: .openURL)
     
     var body: some View {
@@ -31,8 +31,7 @@ struct CompactView: View {
                 }
         } else if case let .tab(tabID) = navigation.currentItem {
             NavigationStack {
-                SearchableContent(tabID: tabID)
-                    .environmentObject(searchViewModel)
+                SearchableContent(viewModel: searchViewModel, tabID: tabID)
                     .searchable(
                         text: $searchViewModel.searchText,
                         placement: .navigationBarDrawer(displayMode: .automatic),
@@ -47,7 +46,7 @@ struct CompactView: View {
 }
 
 private struct SearchableContent: View {
-    @EnvironmentObject private var searchViewModel: SearchViewModel
+    @ObservedObject var viewModel: SearchViewModel
     @Environment(\.isSearching) private var isSearching
     let tabID: NSManagedObjectID
     
@@ -55,8 +54,7 @@ private struct SearchableContent: View {
         CompactTabView(tabID: tabID)
             .overlay {
                 if isSearching {
-                    SearchResults()
-                        .environmentObject(searchViewModel)
+                    SearchResults(viewModel: viewModel)
                 }
             }
     }

--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -263,6 +263,7 @@
 
 "search_result.zimfile.empty.message" = "No opened ZIM file";
 "search_result.zimfile.no_result.message" = "No result";
+"search_result.zimfile.voice_over_count" = "Found results: %@";
 "search_result.sidebar.button.remove" = "Remove";
 "search_result.header.text" = "Recent Search";
 "search_result.button.clear" = "Clear";

--- a/Support/qqq.lproj/Localizable.strings
+++ b/Support/qqq.lproj/Localizable.strings
@@ -222,6 +222,7 @@
 "bookmark.overlay.empty.title" = "Fallback text displayed in center, when there are no bookmarks";
 "search_result.zimfile.empty.message" = "Fallback text on search results";
 "search_result.zimfile.no_result.message" = "Fallback text on search results";
+"search_result.zimfile.voice_over_count" = "Voice over / accessibility text to announce the count of results found.";
 "search_result.sidebar.button.remove" = "Button text on search results, to remove former results";
 "search_result.header.text" = "Title for listing the recent search results";
 "search_result.button.clear" = "Button title for clearing the recent search results";

--- a/ViewModel/SearchViewModel.swift
+++ b/ViewModel/SearchViewModel.swift
@@ -66,6 +66,15 @@ enum SearchResultItems {
             suggestions.endIndex
         }
     }
+    
+    var count: Int {
+        switch self {
+        case let .results(results):
+            results.count
+        case let .suggestions(suggestions):
+            suggestions.count
+        }
+    }
 }
 
 @MainActor
@@ -74,16 +83,13 @@ final class SearchViewModel: NSObject, ObservableObject, NSFetchedResultsControl
     @Published private(set) var zimDataDict: [UUID: ZimArticleData]  // ID of zim files that are included in search
     @Published private(set) var inProgress = false
     @Published private(set) var results: SearchResultItems = .results([])
-    
-    @MainActor
-    static let shared = SearchViewModel()
 
     private let fetchedResultsController: NSFetchedResultsController<ZimFile>
     private var searchSubscriber: AnyCancellable?
     @ZimActor
     private let queue = OperationQueue()
 
-    override private init() {
+    override init() {
         // initialize fetched results controller
         let predicate = NSPredicate(
             format: "includedInSearch == true AND fileURLBookmark != nil"

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -25,159 +25,80 @@ struct BrowserTab: View {
     @StateObject private var search = SearchViewModel.shared
     /// used on iPad
     private let didChangeTitle: ((NSManagedObjectID, String) -> Void)?
-
+    
     init(tabID: NSManagedObjectID, didChangeTitle: ((NSManagedObjectID, String) -> Void)? = nil) {
         self.didChangeTitle = didChangeTitle
         self.browser = BrowserViewModel.getCached(tabID: tabID)
     }
-
+    
     var body: some View {
         let model = if FeatureFlags.hasLibrary {
             CatalogLaunchViewModel(library: library, browser: browser)
         } else {
             NoCatalogLaunchViewModel(browser: browser)
         }
-        Content(browser: browser, model: model).toolbar {
+        Content(browser: browser, model: model)
+            .environmentObject(search)
+            .focusedSceneValue(\.isBrowserURLSet, browser.url != nil)
 #if os(macOS)
-            ToolbarItemGroup(placement: .navigation) {
-                NavigationButtons(
-                    goBack: { [weak browser] in
-                        browser?.webView.goBack()
-                    },
-                    goForward: { [weak browser] in
-                        browser?.webView.goForward()
-                    })
+            .focusedSceneValue(\.browserURL, browser.url)
+#endif
+            .focusedSceneValue(\.canGoBack, browser.canGoBack)
+            .focusedSceneValue(\.canGoForward, browser.canGoForward)
+            .modifier(ExternalLinkHandler(externalURL: $browser.externalURL))
+            .searchable(
+                text: $search.searchText,
+                placement: .toolbarPrincipal,
+                prompt: LocalString.common_search
+            )
+            .onChange(of: scenePhase) { [weak browser] _, newValue in
+                switch newValue {
+                case .active:
+                    browser?.refreshVideoState()
+                case .inactive:
+                    Task { [weak browser] in
+                        await browser?.persistState()
+                    }
+                case .background:
+                    break
+                @unknown default:
+                    break
+                }
             }
+            .modify { [weak browser] view in
+#if os(macOS)
+                if let browser {
+                    view.navigationTitle(browser.articleTitle.isEmpty ? Brand.appName : browser.articleTitle)
+                        .navigationSubtitle(browser.zimFileName)
+                } else {
+                    view
+                }
 #elseif os(iOS)
-            ToolbarItemGroup(placement: .navigationBarLeading) {
-                NavigationButtons(
-                    goBack: { [weak browser] in
-                        browser?.webView.goBack()
-                    },
-                    goForward: { [weak browser] in
-                        browser?.webView.goForward()
-                    })
+                view
+#endif
             }
-#endif
-            ToolbarItemGroup(placement: .primaryAction) {
-                if !Brand.hideTOCButton {
-                    OutlineButton(browser: browser)
-                }
-#if os(iOS)
-                if !Brand.hideShareButton {
-                    ExportButton(
-                        articleTitle: browser.articleTitle,
-                        webViewURL: browser.webView.url,
-                        pageDataWithExtension: { [weak browser] in await browser?.pageDataWithExtension() },
-                        isButtonDisabled: browser.zimFileName.isEmpty
-                    )
-                }
-#else
-                if !Brand.hideShareButton {
-                    Menu {
-                        ExportButton(
-                            relativeToView: browser.webView,
-                            articleTitle: browser.articleTitle,
-                            webViewURL: browser.webView.url,
-                            pageDataWithExtension: { [weak browser] in await browser?.pageDataWithExtension() },
-                            isButtonDisabled: browser.zimFileName.isEmpty,
-                            buttonLabel: LocalString.common_button_share_as_pdf
-                        )
-                        if let url = browser.webView.url {
-                            Button(LocalString.common_button_copy) {
-                                CopyPaste.copyToPasteBoard(url: url)
-                            }
-                            .keyboardShortcut("c", modifiers: [.command, .shift])
-                        }
-                    } label: {
-                        Label(LocalString.common_button_share, systemImage: "square.and.arrow.up")
-                    }.disabled(browser.webView.url == nil)
-                }
-                if !Brand.hidePrintButton {
-                    PrintButton(articleTitle: { [weak browser] in
-                        browser?.articleTitle
-                    }, browserDataAsPDF: { [weak browser] in
-                        try await browser?.webView.pdf()
-                    })
-                }
-#endif
-                BookmarkButton(articleBookmarked: browser.articleBookmarked,
-                               isButtonDisabled: browser.zimFileName.isEmpty,
-                               createBookmark: { [weak browser] in browser?.createBookmark() },
-                               deleteBookmark: { [weak browser] in browser?.deleteBookmark() })
-#if os(iOS)
-                if !Brand.hideFindInPage {
-                    ContentSearchButton(browser: browser)
-                }
-#endif
-                ArticleShortcutButtons(
-                    loadMainArticle: { [weak browser] zimFileID in
-                        browser?.loadMainArticle(zimFileID: zimFileID)
-                    },
-                    loadRandomArticle: { [weak browser] zimFileID in
-                        browser?.loadRandomArticle(zimFileID: zimFileID)
-                    })
+            .task { [weak browser] in
+                await browser?.updateLastOpened()
             }
-        }
-        .environmentObject(search)
-        .focusedSceneValue(\.isBrowserURLSet, browser.url != nil)
-#if os(macOS)
-        .focusedSceneValue(\.browserURL, browser.url)
-#endif
-        .focusedSceneValue(\.canGoBack, browser.canGoBack)
-        .focusedSceneValue(\.canGoForward, browser.canGoForward)
-        .modifier(ExternalLinkHandler(externalURL: $browser.externalURL))
-        .searchable(
-            text: $search.searchText,
-            placement: .toolbarPrincipal,
-            prompt: LocalString.common_search
-        )
-        .onChange(of: scenePhase) { [weak browser] _, newValue in
-            switch newValue {
-            case .active:
-                browser?.refreshVideoState()
-            case .inactive:
+            .onChange(of: browser.articleTitle) { [weak browser] oldTitle, newTitle in
+                guard let browser, newTitle != oldTitle else { return }
+                didChangeTitle?(browser.tabID, newTitle)
+            }
+            .onDisappear { [weak browser] in
+                browser?.pauseVideoWhenNotInPIP()
                 Task { [weak browser] in
                     await browser?.persistState()
                 }
-            case .background:
-                break
-            @unknown default:
-                break
             }
-        }
-        .modify { [weak browser] view in
-#if os(macOS)
-            if let browser {
-                view.navigationTitle(browser.articleTitle.isEmpty ? Brand.appName : browser.articleTitle)
-                    .navigationSubtitle(browser.zimFileName)
-            } else {
-                view
-            }
-#elseif os(iOS)
-            view
-#endif
-        }
-        .task { [weak browser] in
-            await browser?.updateLastOpened()
-        }
-        .onChange(of: browser.articleTitle) { [weak browser] oldTitle, newTitle in
-            guard let browser, newTitle != oldTitle else { return }
-            didChangeTitle?(browser.tabID, newTitle)
-        }
-        .onDisappear { [weak browser] in
-            browser?.pauseVideoWhenNotInPIP()
-            Task { [weak browser] in
-                await browser?.persistState()
-            }
-        }
     }
-
+    
     private struct Content<LaunchModel>: View where LaunchModel: LaunchProtocol {
         @Environment(\.horizontalSizeClass) private var horizontalSizeClass
         let browser: BrowserViewModel
         @EnvironmentObject private var library: LibraryViewModel
         @EnvironmentObject private var navigation: NavigationViewModel
+        @Environment(\.isSearching) private var isSearching
+        @Environment(\.dismissSearch) private var dismissSearch
         @FetchRequest(
             sortDescriptors: [NSSortDescriptor(keyPath: \ZimFile.size, ascending: false)],
             predicate: ZimFile.openedPredicate()
@@ -187,14 +108,18 @@ struct BrowserTab: View {
         @Default(.hasSeenCategories) private var hasSeenCategories
         @ObservedObject var model: LaunchModel
         @StateObject private var search = SearchViewModel.shared
-
+        
+        private var isSearchingState: Bool {
+            isSearching || !search.searchText.isEmpty
+        }
+        
         var body: some View {
             // swiftlint:disable:next redundant_discardable_let
             let _ = model.updateWith(hasZimFiles: !zimFiles.isEmpty,
                                      hasSeenCategories: hasSeenCategories)
             GeometryReader { proxy in
                 Group {
-                    if !search.searchText.isEmpty {
+                    if isSearchingState {
                         SearchResults()
                             .environment(\.horizontalSizeClass, proxy.size.width > 650 ? .regular : .compact)
                     } else {
@@ -237,6 +162,90 @@ struct BrowserTab: View {
             .onChange(of: library.state) { _, state in
                 guard state == .complete else { return }
                 showTheLibrary()
+            }
+            .toolbar {
+                if !isSearchingState {
+#if os(macOS)
+                    ToolbarItemGroup(placement: .navigation) {
+                        NavigationButtons(
+                            goBack: { [weak browser] in
+                                browser?.webView.goBack()
+                            },
+                            goForward: { [weak browser] in
+                                browser?.webView.goForward()
+                            })
+                    }
+#elseif os(iOS)
+                    ToolbarItemGroup(placement: .navigationBarLeading) {
+                        NavigationButtons(
+                            goBack: { [weak browser] in
+                                browser?.webView.goBack()
+                            },
+                            goForward: { [weak browser] in
+                                browser?.webView.goForward()
+                            })
+                    }
+#endif
+                    ToolbarItemGroup(placement: .primaryAction) {
+                        if !Brand.hideTOCButton {
+                            OutlineButton(browser: browser)
+                        }
+#if os(iOS)
+                        if !Brand.hideShareButton {
+                            ExportButton(
+                                articleTitle: browser.articleTitle,
+                                webViewURL: browser.webView.url,
+                                pageDataWithExtension: { [weak browser] in await browser?.pageDataWithExtension() },
+                                isButtonDisabled: browser.zimFileName.isEmpty
+                            )
+                        }
+#else
+                        if !Brand.hideShareButton {
+                            Menu {
+                                ExportButton(
+                                    relativeToView: browser.webView,
+                                    articleTitle: browser.articleTitle,
+                                    webViewURL: browser.webView.url,
+                                    pageDataWithExtension: { [weak browser] in await browser?.pageDataWithExtension() },
+                                    isButtonDisabled: browser.zimFileName.isEmpty,
+                                    buttonLabel: LocalString.common_button_share_as_pdf
+                                )
+                                if let url = browser.webView.url {
+                                    Button(LocalString.common_button_copy) {
+                                        CopyPaste.copyToPasteBoard(url: url)
+                                    }
+                                    .keyboardShortcut("c", modifiers: [.command, .shift])
+                                }
+                            } label: {
+                                Label(LocalString.common_button_share, systemImage: "square.and.arrow.up")
+                            }.disabled(browser.webView.url == nil)
+                        }
+                        if !Brand.hidePrintButton {
+                            PrintButton(articleTitle: { [weak browser] in
+                                browser?.articleTitle
+                            }, browserDataAsPDF: { [weak browser] in
+                                try await browser?.webView.pdf()
+                            })
+                        }
+#endif
+                        BookmarkButton(articleBookmarked: browser.articleBookmarked,
+                                       isButtonDisabled: browser.zimFileName.isEmpty,
+                                       createBookmark: { [weak browser] in browser?.createBookmark() },
+                                       deleteBookmark: { [weak browser] in browser?.deleteBookmark() })
+#if os(iOS)
+                        if !Brand.hideFindInPage {
+                            ContentSearchButton(browser: browser)
+                        }
+#endif
+                        ArticleShortcutButtons(
+                            loadMainArticle: { [weak browser] zimFileID in
+                                browser?.loadMainArticle(zimFileID: zimFileID)
+                            },
+                            loadRandomArticle: { [weak browser] zimFileID in
+                                browser?.loadRandomArticle(zimFileID: zimFileID)
+                            })
+                    }
+                }
             }
         }
 

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -22,7 +22,7 @@ struct BrowserTab: View {
     @ObservedObject var browser: BrowserViewModel
     @Environment(\.scenePhase) private var scenePhase
     @EnvironmentObject private var library: LibraryViewModel
-    @StateObject private var search = SearchViewModel.shared
+    @StateObject private var search = SearchViewModel()
     /// used on iPad
     private let didChangeTitle: ((NSManagedObjectID, String) -> Void)?
     
@@ -37,7 +37,7 @@ struct BrowserTab: View {
         } else {
             NoCatalogLaunchViewModel(browser: browser)
         }
-        Content(browser: browser, model: model)
+        Content(browser: browser, model: model, search: search)
             .environmentObject(search)
             .focusedSceneValue(\.isBrowserURLSet, browser.url != nil)
 #if os(macOS)
@@ -107,7 +107,7 @@ struct BrowserTab: View {
         /// which triggers the model to be revalidated
         @Default(.hasSeenCategories) private var hasSeenCategories
         @ObservedObject var model: LaunchModel
-        @StateObject private var search = SearchViewModel.shared
+        @ObservedObject var search: SearchViewModel
         
         private var isSearchingState: Bool {
             isSearching || !search.searchText.isEmpty
@@ -119,8 +119,8 @@ struct BrowserTab: View {
                                      hasSeenCategories: hasSeenCategories)
             GeometryReader { proxy in
                 Group {
-                    if isSearchingState {
-                        SearchResults()
+                    if !search.searchText.isEmpty {
+                        SearchResults(viewModel: search)
                             .environment(\.horizontalSizeClass, proxy.size.width > 650 ? .regular : .compact)
                     } else {
                         switch model.state {

--- a/Views/Search/SearchList.swift
+++ b/Views/Search/SearchList.swift
@@ -1,0 +1,38 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import SwiftUI
+
+struct SearchList<Content: View>: View {
+    let content: Content
+    
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+    
+    var body: some View {
+#if os(macOS)
+        // SwiftUI issue: LazyVGrid is not applying .modifier to recycled items
+        // which stops the keyboard navigation "below the fold"
+        Grid {
+            content
+        }
+#else
+        LazyVGrid(columns: [GridItem(.flexible(minimum: 300, maximum: 700), alignment: .center)]) {
+            content
+        }
+#endif
+    }
+}

--- a/Views/Search/SearchResults.swift
+++ b/Views/Search/SearchResults.swift
@@ -34,22 +34,6 @@ struct SearchResults: View {
 
     var body: some View {
         Group {
-#if os(macOS)
-            // Special hidden button to enable down key response when
-            // search is active, to go to search results
-            if isSearching, focusedSearchItem == nil {
-                Button(action: {
-                    switch viewModel.results {
-                    case let .results(results):
-                        focusedSearchItem = results.first?.url.absoluteString
-                    case let .suggestions(suggestions):
-                        focusedSearchItem = suggestions.first
-                    }
-                }, label: {})
-                .hidden()
-                .keyboardShortcut(.downArrow, modifiers: [])
-            }
-#endif
             if zimFiles.isEmpty {
                 Message(text: LocalString.search_result_zimfile_empty_message)
             } else if horizontalSizeClass == .regular {
@@ -88,8 +72,7 @@ struct SearchResults: View {
         } else {
             ScrollViewReader { scrollReader in
                 ScrollView {
-                    LazyVGrid(columns: [GridItem(.flexible(minimum: 300, maximum: 700), alignment: .center)]) {
-                        
+                    SearchList {
                         switch viewModel.results {
                         case let .results(results):
                             ForEach(results, id: \.url.absoluteString) { result in
@@ -146,29 +129,7 @@ struct SearchResults: View {
                     scrollReader.scrollTo(focusedURL, anchor: .center)
                 }
                 .modifier(MoveCommand(perform: { direction in
-                    // macOS only
-                    if let focusedSearchItem,
-                       let index = viewModel.results.firstIndex(where: focusedSearchItem) {
-                        let nextIndex: Int
-                        switch direction {
-                        case .up: nextIndex = viewModel.results.index(before: index)
-                        case .down: nextIndex = viewModel.results.index(after: index)
-                        default: nextIndex = viewModel.results.startIndex
-                        }
-                        if nextIndex < viewModel.results.startIndex {
-                            $focusedSearchItem.wrappedValue = nil
-#if os(macOS)
-                            NotificationCenter.default.post(name: .zimSearch, object: nil)
-#endif
-                        } else if (viewModel.results.startIndex..<viewModel.results.endIndex).contains(nextIndex) {
-                            switch viewModel.results {
-                            case let .results(results):
-                                $focusedSearchItem.wrappedValue = results[nextIndex].url.absoluteString
-                            case let .suggestions(suggestions):
-                                $focusedSearchItem.wrappedValue = suggestions[nextIndex]
-                            }
-                        }
-                    }
+                    onMove(direction: direction) // macOS only
                 }))
                 .overlay(alignment: .center) {
                     if viewModel.inProgress {
@@ -179,6 +140,30 @@ struct SearchResults: View {
         }
     }
     
+    // macOS only
+    private func onMove(direction: MoveDirection) {
+        let index: Int = if let item = focusedSearchItem {
+            viewModel.results.firstIndex(where: item) ?? -1
+        } else {
+            -1
+        }
+        let nextIndex: Int
+        switch direction {
+        case .up: nextIndex = viewModel.results.index(before: index)
+        case .down: nextIndex = viewModel.results.index(after: index)
+        default: nextIndex = viewModel.results.startIndex
+        }
+        if (viewModel.results.startIndex..<viewModel.results.endIndex).contains(nextIndex) {
+            switch viewModel.results {
+            case let .results(results):
+                let urlString = results[nextIndex].url.absoluteString
+                focusedSearchItem = urlString
+            case let .suggestions(suggestions):
+                focusedSearchItem = suggestions[nextIndex]
+            }
+        }
+    }
+
     private func openResult(result: SearchResult) {
         recentSearchTexts = {
             var searchTexts = Defaults[.recentSearchTexts]

--- a/Views/Search/SearchResults.swift
+++ b/Views/Search/SearchResults.swift
@@ -23,7 +23,7 @@ struct SearchResults: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.managedObjectContext) private var managedObjectContext
     @Environment(\.isSearching) private var isSearching
-    @EnvironmentObject private var viewModel: SearchViewModel
+    @ObservedObject var viewModel: SearchViewModel
     @EnvironmentObject private var navigation: NavigationViewModel
     @FocusState private var focusedSearchItem: String? // macOS only
     @FetchRequest(
@@ -52,6 +52,15 @@ struct SearchResults: View {
                 content
             }
         }
+        .onChange(of: viewModel.results.count, { _, newValue in
+            switch newValue {
+            case 0:
+                voiceOver(announcement: LocalString.search_result_zimfile_no_result_message)
+            default:
+                // TODO: localisation
+                voiceOver(announcement: "Found results: \(newValue)")
+            }
+        })
         .background(Color.background)
     }
     
@@ -81,6 +90,8 @@ struct SearchResults: View {
                                 } label: {
                                     ArticleCell(result: result, zimData: viewModel.zimDataDict[result.zimFileID])
                                 }
+                                .accessibilityLabel(result.title)
+                                .accessibilityHint(result.snippet?.string ?? "")
                                 .buttonStyle(.plain)
                                 .modifier(
                                     Focusable( // macOS only
@@ -138,6 +149,12 @@ struct SearchResults: View {
                 }
             }
         }
+    }
+    
+    private func voiceOver(announcement: String) {
+        var attributed = AttributedString(announcement)
+        attributed.accessibilitySpeechAnnouncementPriority = .low
+        AccessibilityNotification.Announcement(attributed).post()
     }
     
     // macOS only

--- a/Views/Search/SearchResults.swift
+++ b/Views/Search/SearchResults.swift
@@ -52,13 +52,13 @@ struct SearchResults: View {
                 content
             }
         }
-        .onChange(of: viewModel.results.count, { _, newValue in
-            switch newValue {
+        .onReceive(viewModel.$results, perform: { (results: SearchResultItems) in
+            switch results.count {
             case 0:
                 voiceOver(announcement: LocalString.search_result_zimfile_no_result_message)
             default:
-                // TODO: localisation
-                voiceOver(announcement: "Found results: \(newValue)")
+                let resultCountText = LocalString.search_result_zimfile_voice_over_count(withArgs: "\(results.count)")
+                voiceOver(announcement: resultCountText)
             }
         })
         .background(Color.background)


### PR DESCRIPTION
#### Fixes: #1685

## Impact for end user
- Easier search use by hiding buttons that are unrelated to the search itself
- Fixed keyboard navigation consistent with other macOS applications: tab to change from search field to results, up/down keys to navigate within the search results
- The search result count is announce in Voice Over
- The search result title is read first by Voice Over, while the snippet part is a hint (as requested in the issue)

## Description

- Changed:
The LazyVGrid is not working properly with the keyboard navigation on macOS, it has been changed to a plain Grid. That is using slightly more memory but it's working in a reliable fashion.

- Added:
New localization item for the result count announcement

- Removed:
The down button navigation from search field to search results. This is not consistent with other macOS applications (eg Finder), it wasn't working reliable, plus it is conflicting with text input value selection and editing.
Instead the default tab key can be used to "jump" from search input to search results.
To achieve it without any distractions, the unrelated navigation buttons were removed, when we are in search mode. 

## With Voice Over
https://github.com/user-attachments/assets/81086dfa-b242-43ef-a31b-8f9a21afe7e2


## Without Voice Over
https://github.com/user-attachments/assets/604c70b2-b37e-48fa-8676-857001029054



### Tested on
- [x] **iPhone**
- [x] **iPad**
- [x] **mac**