### PR TITLE
Block external URLs and not first-party content

### DIFF
--- a/Model/WebViewConfig/WebContentBlocker.swift
+++ b/Model/WebViewConfig/WebContentBlocker.swift
@@ -45,18 +45,25 @@ enum WebContentBlocker {
             "type": "ignore-previous-rules"
         },
         "trigger": {
-            "url-filter": "zim://"
+            "url-filter": "^zim://",
+            "load-type": ["first-party"]
         }
     }
 ]
 """
-        guard let ruleList: WKContentRuleList = try? await blockListStore.compileContentRuleList(
-            forIdentifier: "externalUrls",
-            encodedContentRuleList: contentRules
-        ) else {
-            Log.URLSchemeHandler.error("blockList failed to compile")
-            return
+        do {
+            guard let ruleList: WKContentRuleList = try await blockListStore.compileContentRuleList(
+                forIdentifier: "externalUrls",
+                encodedContentRuleList: contentRules
+            ) else {
+                Log.URLSchemeHandler.error("blockList failed to compile")
+                assertionFailure("blockList failed to compile")
+                return
+            }
+            Self.ruleList = ruleList
+        } catch {
+            Log.URLSchemeHandler.error("blockList failed to compile: \(error)")
+            assertionFailure("blockList failed to compile: \(error)")
         }
-        Self.ruleList = ruleList
     }
 }


### PR DESCRIPTION
#### Fixes: #1699 

## Impact for end user
Unexpected external URLs won't load.

## Changed:
The block list rules, making sure we both fail early if the rules won't compile, and that we are not allowing malicious content to be loaded via external urls.

## Screenshots

<img width="944" height="502" alt="Screenshot 2026-09-06 at 20 03 59" src="https://github.com/user-attachments/assets/618c52ea-6e6e-4b2c-8a84-ef62116a95ed" />

The external image from the same test ZIM file no longer loads

### Tested on
- [x] **mac**