### PR TITLE
Double block external iframe content

### DIFF
--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -464,8 +464,12 @@ import CoreKiwix
         decidePolicyFor navigationAction: WKNavigationAction
     ) async -> WKNavigationActionPolicy {
         guard navigationAction.targetFrame?.isMainFrame == true else {
-            // Allow to load iFrame content via src-doc instead of external src
-            return .allow
+            if navigationAction.request.url?.isZIMURL == true {
+                // Allow to load iFrame content via src-doc instead of external src
+                return .allow
+            } else {
+                return .cancel
+            }
         }
         guard let url = navigationAction.request.url?.updatedToZIMSheme() else {
             return .cancel


### PR DESCRIPTION
#### Fixes: #1701 

## Impact for end user
There's no impact for end user, it's simply another layer of safety.

## Added
An extra condition to make sure that iframe requests also have the ``zim://`` scheme.


### Tested on
- [ ] **iPhone**
- [ ] **iPad**
- [x] **mac**