### PR TITLE
Clean outlineItems on navigating away

### DIFF
--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -554,6 +554,7 @@ import CoreKiwix
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
         // The previous document's geolocation callbacks are gone
         geolocationService?.stopAll()
+        outlineItems = []
     }
 
     @MainActor


### PR DESCRIPTION
#### Fixes: #1707 

## Impact for end user
Table of contents can no longer can cross pollinate between pages after navigation. 



### Tested on
- [ ] **iPhone**
- [ ] **iPad**
- [x] **mac**