### PR TITLE
Fix language selection and settings

### DIFF
--- a/App/SplitViewForiPad.swift
+++ b/App/SplitViewForiPad.swift
@@ -40,7 +40,7 @@ struct SplitViewForiPad: View { // swiftlint:disable:this type_body_length
     @State private var allSections: [MenuSection] = MenuSection.allMenuSections
     @State private var menuDict: [MenuSection: [MenuItem]] = MenuSection.staticDictionary
     @Default(.savedMenuNavigation) private var selection: MenuItem?
-    @State private var languages = Defaults[.libraryLanguageCodes]
+    @Default(.libraryLanguageCodes) private var languages
     @State private var selectedLang: String = Defaults[.libraryLanguageCodes].first ?? "eng"
     @State private var navPath = NavigationPath()
     @State private var titleUpdate: (NSManagedObjectID, String)?
@@ -94,6 +94,7 @@ struct SplitViewForiPad: View { // swiftlint:disable:this type_body_length
                         .toolbar {
                             ToolbarItem(placement: .topBarTrailing) {
                                 ToggleAroundLanguageButton(items: $languages, selection: $selectedLang)
+                                    .disabled(languages.count <= 1)
                             }
                         }
                 case .new:
@@ -150,6 +151,11 @@ struct SplitViewForiPad: View { // swiftlint:disable:this type_body_length
                 columnVisibility = Defaults[.ipadSplitViewVisibility]
             default:
                 break
+            }
+        }
+        .onChange(of: languages) { (_, new: [String]) in
+            if !new.contains(selectedLang) {
+                selectedLang = new.first ?? "eng"
             }
         }
     }


### PR DESCRIPTION
#### Fixes: #1715 

## Impact for end user
Language selection from Settings will apply immediately.
- Former language selection in Categories will be re-validated after Settings changes.
- When only a single language is available, the toggle button is disabled.

## Screenshots

https://github.com/user-attachments/assets/e1745806-07cc-410b-bc4c-346a0b02bdc3




### Tested on
- [ ] **iPhone**
- [x] **iPad**
- [ ] **mac**