### PR TITLE
Unify language toggle for news and categories

### DIFF
--- a/Views/Library/ZimFilesNew.swift
+++ b/Views/Library/ZimFilesNew.swift
@@ -168,9 +168,8 @@ struct ZimFilesNew: View {
             let languagePlacement: ToolbarItemPlacement = .automatic
 #endif
             ToolbarItem(placement: languagePlacement) {
-                if languageCodes.count > 1 {
-                    ToggleAroundLanguageButton(items: $languageCodes, selection: $selectedLanguage)
-                }
+                ToggleAroundLanguageButton(items: $languageCodes, selection: $selectedLanguage)
+                    .disabled(languageCodes.count <= 1)
             }
 #if os(iOS)
             let refreshPlacement: ToolbarItemPlacement = .title


### PR DESCRIPTION
#### Fixes: #1716 

## Impact for end user
Unified look and behavior of the language toggle toolbar button across categories and new sections.

## Description
- Applied the same logic: if only 1 language is available the button is displayed, but disabled. 

## Screenshots

https://github.com/user-attachments/assets/c711e0f8-fc22-4987-a85e-dd6818ea5d4d




### Tested on
- [ ] **iPhone**
- [x] **iPad**
- [ ] **mac**