### PR TITLE
Exclude downloaded ZIM files from catalog listings

### DIFF
--- a/Views/Library/Categories/ZimFilesCategories.swift
+++ b/Views/Library/Categories/ZimFilesCategories.swift
@@ -159,6 +159,7 @@ struct ZimFilesCategory: View {
         if searchText.isEmpty {
             predicates.append(NSPredicate(format: "category == %@", category.rawValue))
         }
+        predicates.append(ZimFile.Predicate.notDownloaded())
         predicates.append(langPredicate)
         predicates.append(NSPredicate(format: "requiresServiceWorkers == false"))
         if !searchText.isEmpty {

--- a/Views/Library/ZimFilesNew.swift
+++ b/Views/Library/ZimFilesNew.swift
@@ -80,7 +80,8 @@ private final class ViewModel: ObservableObject {
     private static func buildPredicate(searchText: String, languageCodes: [String]) -> NSPredicate {
         var predicates = [
             NSPredicate(format: "languageCode IN %@", languageCodes),
-            NSPredicate(format: "requiresServiceWorkers == false")
+            NSPredicate(format: "requiresServiceWorkers == false"),
+            ZimFile.Predicate.notDownloaded()
         ]
         if let aMonthAgo = Calendar.current.date(byAdding: .month, value: -3, to: Date()) {
             predicates.append(NSPredicate(format: "created > %@", aMonthAgo as CVarArg))


### PR DESCRIPTION
#### Fixes: #1665 

## Impact for end user
- The downloaded ZIM file won't show up in the category listing anymore.
- After a downloading the ZIM and navigating back from the download (detail) section, the item is removed from the listings.

### **iPhone**
https://github.com/user-attachments/assets/7e6e6b3e-b6be-4a57-a841-1012b162b35c

### **iPad**

https://github.com/user-attachments/assets/2522f3c6-247e-43ae-be71-b757e604bfa6

### **mac**

https://github.com/user-attachments/assets/6aa346b6-c170-45e2-9cbd-1293288610dd



